### PR TITLE
 feat: add basic io for characters 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Benedikt <Sayrin@web.de>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+serde = { version = "1.0.118", features = ["derive"] }
+toml = "0.5.8"
+serde_with = "1.6.0"
+
+[dev-dependencies]
+tempfile = "3.1.0"

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,9 +1,13 @@
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Inventory {
     items: Vec<Item>,
 }
 
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Item {
     pub name: String,
     pub amount: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,11 @@ mod inventory;
 pub use self::inventory::Inventory;
 pub use self::inventory::Item;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
 
 // Name: Erwin Müller
 // Role: Corporate Age: 23
@@ -19,6 +22,7 @@ use std::fmt;
 // 0GFight :  1 =  7      | DEATH                   X336110X6210XX3XX0X4332X5XXX06
 // Composit:  1 = 11
 
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Character {
     pub name: String,
     pub role: String,
@@ -28,11 +32,15 @@ pub struct Character {
     pub skills: Vec<Skill>,
 }
 
-pub struct Attributes(HashMap<Attribute, AttributeValue>);
+#[serde_as]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attributes(
+    #[serde_as(as = "BTreeMap<DisplayFromStr, _>")] BTreeMap<Attribute, AttributeValue>,
+);
 
 impl Attributes {
     pub fn new() -> Self {
-        let mut m = HashMap::new();
+        let mut m = BTreeMap::new();
 
         m.insert(Attribute::Attractiveness, AttributeValue::new(0, 0));
         m.insert(Attribute::Move, AttributeValue::new(0, 0));
@@ -62,7 +70,7 @@ impl fmt::Display for Attributes {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Attribute {
     Attractiveness,
     Move,
@@ -75,6 +83,32 @@ pub enum Attribute {
     Tech,
 }
 
+impl fmt::Display for Attribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::str::FromStr for Attribute {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match &*s.to_lowercase() {
+            "attractiveness" => Ok(Self::Attractiveness),
+            "move" => Ok(Self::Move),
+            "coolness" => Ok(Self::Coolness),
+            "empathy" => Ok(Self::Empathy),
+            "luck" => Ok(Self::Luck),
+            "intelligence" => Ok(Self::Intelligence),
+            "body" => Ok(Self::Body),
+            "reflexes" => Ok(Self::Reflexes),
+            "tech" => Ok(Self::Tech),
+            _ => Err(format!("Unknown attribute: {}", s)),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttributeValue {
     pub base: usize,
     pub actual: usize,
@@ -115,8 +149,35 @@ Character {{ \n\
             println!("\t {}: {}", skill.name, total);
         }
     }
+
+    /// Write the character to the provided `io::Write`er.
+    pub fn write(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
+        let serialized = toml::to_string_pretty(self).map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to serialize character: {}", err),
+            )
+        })?;
+
+        w.write_all(serialized.as_bytes())
+    }
+
+    /// Reads a character from the provided `io::Read`er.
+    pub fn from_reader(r: &mut impl std::io::Read) -> std::io::Result<Self> {
+        let mut serialized = String::new();
+        r.read_to_string(&mut serialized)?;
+        let character = toml::from_str(&serialized).map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("failed to deserialize character: {}", err),
+            )
+        })?;
+
+        Ok(character)
+    }
 }
 
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Skill {
     pub name: String,
     pub base: Attribute,
@@ -179,5 +240,133 @@ impl fmt::Display for List {
 
         // Close the opened bracket and return a fmt::Result value.
         write!(f, "")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::{Seek, SeekFrom};
+
+    #[test]
+    fn test_char_ser_de() {
+        let mut erwin = Character {
+            name: "Erwin Müller".to_string(),
+            role: "Corporate".to_string(),
+            age: 23,
+            attributes: Attributes::new(),
+            inventory: Inventory::new(),
+            skills: vec![Skill::new(
+                "schleichen".to_string(),
+                Attribute::Reflexes,
+                2,
+                3,
+            )],
+        };
+        erwin.inventory.push(Item::new(
+            "Broomstick".to_string(),
+            1,
+            1500,
+            0,
+            "Alright you primitive Screwheads, listen up, this is my BROOMSTICK".to_string(),
+        ));
+
+        let serialized_erwin = toml::to_string_pretty(&erwin).unwrap();
+        assert_eq!(
+            serialized_erwin,
+            r#"name = 'Erwin Müller'
+role = 'Corporate'
+age = 23
+[attributes.Attractiveness]
+base = 0
+actual = 0
+
+[attributes.Move]
+base = 0
+actual = 0
+
+[attributes.Coolness]
+base = 0
+actual = 0
+
+[attributes.Empathy]
+base = 0
+actual = 0
+
+[attributes.Luck]
+base = 0
+actual = 0
+
+[attributes.Intelligence]
+base = 0
+actual = 0
+
+[attributes.Body]
+base = 0
+actual = 0
+
+[attributes.Reflexes]
+base = 0
+actual = 0
+
+[attributes.Tech]
+base = 0
+actual = 0
+[[inventory.items]]
+name = 'Broomstick'
+amount = 1
+weight_grams = 1500
+price_eb = 0
+comment = 'Alright you primitive Screwheads, listen up, this is my BROOMSTICK'
+
+[[skills]]
+name = 'schleichen'
+base = 'Reflexes'
+level = 2
+level_up_modifierer = 3
+"#
+        );
+        let deserialized_erwin: Character = toml::from_str(&serialized_erwin).unwrap();
+        assert_eq!(deserialized_erwin, erwin);
+    }
+
+    #[test]
+    fn test_char_io() {
+        let mut erwin = Character {
+            name: "Erwin Müller".to_string(),
+            role: "Corporate".to_string(),
+            age: 23,
+            attributes: Attributes::new(),
+            inventory: Inventory::new(),
+            skills: vec![Skill::new(
+                "schleichen".to_string(),
+                Attribute::Reflexes,
+                2,
+                3,
+            )],
+        };
+        erwin.inventory.push(Item::new(
+            "Broomstick".to_string(),
+            1,
+            1500,
+            0,
+            "Alright you primitive Screwheads, listen up, this is my BROOMSTICK".to_string(),
+        ));
+
+        // create a temporary file, which will be deleted at the end of this test, when it goes out of scope
+        let mut file = tempfile::tempfile().unwrap();
+
+        // write the erwin char to the file
+        erwin.write(&mut file).unwrap();
+
+        // reset the file, by seeking to pos 0
+        file.seek(SeekFrom::Start(0)).unwrap();
+
+        // load the character from the file
+        let new_erwin = Character::from_reader(&mut file).unwrap();
+
+        // check that the original character and the loaded are the same
+        assert_eq!(erwin, new_erwin);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 mod inventory;
 pub use self::inventory::Inventory;
 pub use self::inventory::Item;
+
+use std::collections::HashMap;
 use std::fmt;
 
 // Name: Erwin Müller
@@ -21,74 +23,103 @@ pub struct Character {
     pub name: String,
     pub role: String,
     pub age: usize,
-    pub att: Attribute,
-    pub mov: Attribute,
-    pub coo: Attribute,
-    pub emp: Attribute,
-    pub luck: Attribute,
-    pub int: Attribute,
-    pub body: Attribute,
-    pub refl: Attribute,
-    pub tec: Attribute,
+    pub attributes: Attributes,
     pub inventory: Inventory,
+    pub skills: Vec<Skill>,
 }
 
-pub struct Attribute {
+pub struct Attributes(HashMap<Attribute, AttributeValue>);
+
+impl Attributes {
+    pub fn new() -> Self {
+        let mut m = HashMap::new();
+
+        m.insert(Attribute::Attractiveness, AttributeValue::new(0, 0));
+        m.insert(Attribute::Move, AttributeValue::new(0, 0));
+        m.insert(Attribute::Coolness, AttributeValue::new(0, 0));
+        m.insert(Attribute::Empathy, AttributeValue::new(0, 0));
+        m.insert(Attribute::Luck, AttributeValue::new(0, 0));
+        m.insert(Attribute::Intelligence, AttributeValue::new(0, 0));
+        m.insert(Attribute::Body, AttributeValue::new(0, 0));
+        m.insert(Attribute::Reflexes, AttributeValue::new(0, 0));
+        m.insert(Attribute::Tech, AttributeValue::new(0, 0));
+
+        Attributes(m)
+    }
+
+    pub fn get(&self, attr: &Attribute) -> Option<&AttributeValue> {
+        self.0.get(attr)
+    }
+}
+
+impl fmt::Display for Attributes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Attributes {{")?;
+        for (key, value) in &self.0 {
+            writeln!(f, "\t{:?}: {}", key, value)?;
+        }
+        writeln!(f, "}}")
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum Attribute {
+    Attractiveness,
+    Move,
+    Coolness,
+    Empathy,
+    Luck,
+    Intelligence,
+    Body,
+    Reflexes,
+    Tech,
+}
+
+pub struct AttributeValue {
     pub base: usize,
     pub actual: usize,
 }
 
-impl Attribute {
+impl AttributeValue {
     pub fn new(actual: usize, base: usize) -> Self {
-        Attribute { base, actual }
+        AttributeValue { base, actual }
     }
 }
 
-impl fmt::Display for Attribute {
+impl fmt::Display for AttributeValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}/{}", self.actual, self.base)
     }
 }
 
 impl Character {
-    pub fn print(self) {
+    pub fn print(&self) {
         println!(
             "\
 Character {{ \n\
 \tname: {}\n\
 \trole: {}\n\
 \tage: {}\n\
-\tatt: {}\n\
-\tmov: {}\n\
-\tcoo: {}\n\
-\temp: {}\n\
-\tluck: {}\n\
-\tint: {}\n\
-\tbody: {}\n\
-\tref: {}\n\
-\ttec: {}\n\
+\t{}\n
 \tInventory: {}\n\
 }}",
-            self.name,
-            self.role,
-            self.age,
-            self.att,
-            self.mov,
-            self.coo,
-            self.emp,
-            self.luck,
-            self.int,
-            self.body,
-            self.refl,
-            self.tec,
-            self.inventory,
+            self.name, self.role, self.age, self.attributes, self.inventory,
         );
+    }
+
+    pub fn print_skills(&self) {
+        println!("Skills:");
+        for skill in &self.skills {
+            let attr = self.attributes.get(&skill.base).unwrap();
+            let total = skill.level + attr.actual;
+            println!("\t {}: {}", skill.name, total);
+        }
     }
 }
 
 pub struct Skill {
     pub name: String,
-    pub base: usize,
+    pub base: Attribute,
     pub level: usize,
     pub level_up_modifierer: usize,
 }
@@ -97,20 +128,15 @@ impl Skill {
     pub fn print(self) {
         println!(
             "Skillname {} {{
-            \ttotal: {} 
-            \tbase: {} 
+            \tbase: {:?} 
             \tlevel: {} 
             \tlevel up modifeier: {}
         }}",
-            self.name,
-            self.base + self.level,
-            self.base,
-            self.level,
-            self.level_up_modifierer
+            self.name, self.base, self.level, self.level_up_modifierer
         )
     }
 
-    pub fn new(name: String, base: usize, level: usize, level_up_modifierer: usize) -> Self {
+    pub fn new(name: String, base: Attribute, level: usize, level_up_modifierer: usize) -> Self {
         Skill {
             name,
             base,
@@ -122,7 +148,11 @@ impl Skill {
 
 impl fmt::Display for Skill {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "name: {} total: {}", self.name, self.level + self.base)
+        write!(
+            f,
+            "name: {} base: {:?} level: {}",
+            self.name, self.base, self.level
+        )
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use rusted_punk::{Attribute, Character, Inventory, Item, List, Skill};
+use rusted_punk::{Attribute, Attributes, Character, Inventory, Item, List, Skill};
 
 fn main() {
     character_test();
@@ -11,16 +11,14 @@ fn character_test() {
         name: "Erwin Müller".to_string(),
         role: "Corporate".to_string(),
         age: 23,
-        att: Attribute::new(3, 3),
-        mov: Attribute::new(4, 4),
-        coo: Attribute::new(1, 3),
-        emp: Attribute::new(3, 3),
-        luck: Attribute::new(3, 3),
-        int: Attribute::new(10, 10),
-        body: Attribute::new(7, 7),
-        refl: Attribute::new(6, 6),
-        tec: Attribute::new(10, 10),
+        attributes: Attributes::new(),
         inventory: Inventory::new(),
+        skills: vec![Skill::new(
+            "schleichen".to_string(),
+            Attribute::Reflexes,
+            2,
+            3,
+        )],
     };
     cool_guy.inventory.push(Item::new(
         "Broomstick".to_string(),
@@ -30,19 +28,22 @@ fn character_test() {
         "Alright you primitive Screwheads, listen up, this is my BROOMSTICK".to_string(),
     ));
     cool_guy.print();
+
+    cool_guy.print_skills();
 }
 
 fn skill_test() {
-    let skill = Skill::new("Schleichen".to_string(), 7, 2, 3);
+    let skill = Skill::new("Schleichen".to_string(), Attribute::Reflexes, 2, 3);
     skill.print()
 }
 
 // keine ahnung warum aber es geht
 fn list_test() {
     let v = List(vec![
-        Skill::new("schleichen".to_string(), 4, 2, 3),
-        Skill::new("schiesen".to_string(), 7, 4, 3),
-        Skill::new("werfen".to_string(), 6, 2, 3),
+        Skill::new("schleichen".to_string(), Attribute::Reflexes, 2, 3),
+        Skill::new("schiesen".to_string(), Attribute::Reflexes, 4, 3),
+        Skill::new("werfen".to_string(), Attribute::Reflexes, 2, 3),
+        Skill::new("Erste Hilfe".to_string(), Attribute::Tech, 2, 3),
     ]);
     println!("{}", v);
 }


### PR DESCRIPTION
- Allows for serialization and deserialization using the [serde](https://serde.rs/) crate. The standard for this in Rust.
- Adds methods to the `Character` to allow reading and writing serialized characters
- Adds basic tests for string ser/de and file ser/de for a character

Depends on #6

Closes #8