### PR TITLE
refactor: use i32 for game values instead of usize

### DIFF
--- a/src/armor.rs
+++ b/src/armor.rs
@@ -10,18 +10,18 @@ use serde_with::{serde_as, DisplayFromStr};
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Armor {
-    pub protection_max: usize,
+    pub protection_max: i32,
     pub is_hard: bool,
-    pub encumberance: usize,
+    pub encumberance: i32,
     pub item: Item,
     #[serde_as(as = "BTreeMap<DisplayFromStr, _>")]
-    pub protection_current: BTreeMap<HitZone, usize>,
+    pub protection_current: BTreeMap<HitZone, i32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DamageResult {
-    pub remaining_damage: usize,
-    pub absorbed_damage: usize,
+    pub remaining_damage: i32,
+    pub absorbed_damage: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Copy, Clone, PartialOrd, Ord)]
@@ -115,10 +115,10 @@ impl Armor {
         weight_grams: usize,
         price_eb: usize,
         comment: String,
-        protection_max: usize,
+        protection_max: i32,
         protected_zones: Vec<HitZone>,
         is_hard: bool,
-        encumberance: usize,
+        encumberance: i32,
     ) -> Self {
         let mut protection_current = BTreeMap::new();
         for zone in protected_zones {
@@ -156,7 +156,7 @@ impl Armor {
     /// # Returns
     ///
     /// A `DamageResult` containing the remaining damage and the amount absorbed by the armor
-    pub fn hit(&mut self, damage: usize, zone: HitZone, damage_type: DamageType) -> DamageResult {
+    pub fn hit(&mut self, damage: i32, zone: HitZone, damage_type: DamageType) -> DamageResult {
         if self.protection_current.contains_key(&zone) {
             let mut remaining_damage = damage;
             let absorbed_damage;
@@ -189,7 +189,7 @@ impl Armor {
     /// Armor-piercing weapons halve the effective protection of the armor.
     /// Any remaining damage is halved at the end.
     /// This function also reduces the armor's durability by 1, IF the armor has been penetrated.
-    fn hit_armor_piercing(&mut self, zone: HitZone, remaining_damage: &mut usize) -> usize {
+    fn hit_armor_piercing(&mut self, zone: HitZone, remaining_damage: &mut i32) -> i32 {
         let protection = self.protection_current[&zone] / 2;
         let absorbed_damage;
 
@@ -209,7 +209,7 @@ impl Armor {
     /// Blunt weapons use the full protection value of the armor.
     /// No additional damage modifications are applied.
     /// This function also reduces the armor's durability by 1, IF the armor has been penetrated.
-    fn hit_blunt(&mut self, zone: HitZone, remaining_damage: &mut usize) -> usize {
+    fn hit_blunt(&mut self, zone: HitZone, remaining_damage: &mut i32) -> i32 {
         let absorbed_damage;
 
         if self.protection_current[&zone] >= *remaining_damage {
@@ -227,7 +227,7 @@ impl Armor {
     /// Hollow-point weapons halve the incoming damage before armor calculation.
     /// The armor uses its full protection value against the reduced damage.
     /// This function also reduces the armor's durability by 1, IF the armor has been penetrated.
-    fn hit_hollow_point(&mut self, zone: HitZone, remaining_damage: &mut usize) -> usize {
+    fn hit_hollow_point(&mut self, zone: HitZone, remaining_damage: &mut i32) -> i32 {
         let protection = self.protection_current[&zone];
         *remaining_damage = (*remaining_damage + 1) / 2;
         let absorbed_damage;
@@ -248,7 +248,7 @@ impl Armor {
     /// Against soft armor, the effective protection is halved.
     /// Other then armor piercing damage, the remaining damage is not halved.
     /// This function also reduces the armor's durability by 1, IF the armor has been penetrated.
-    fn hit_slashing(&mut self, zone: HitZone, remaining_damage: &mut usize) -> usize {
+    fn hit_slashing(&mut self, zone: HitZone, remaining_damage: &mut i32) -> i32 {
         let mut protection = self.protection_current[&zone];
         if !self.is_hard {
             protection = (protection + 1) / 2;
@@ -498,11 +498,11 @@ pub mod tests {
 
     fn test_armor_hit(
         armor: &mut Armor,
-        damage: usize,
+        damage: i32,
         damage_type: DamageType,
-        expected_remaining_damage: usize,
-        expected_absorbed_damage: usize,
-        expected_remaining_protection: usize,
+        expected_remaining_damage: i32,
+        expected_absorbed_damage: i32,
+        expected_remaining_protection: i32,
     ) {
         let context = format!("{} {:?} against {}", damage, damage_type, armor.item.name);
         let result = armor.hit(damage, HitZone::Chest, damage_type);

--- a/src/character.rs
+++ b/src/character.rs
@@ -11,8 +11,8 @@ use serde_with::{serde_as, DisplayFromStr};
 pub struct Character {
     pub name: String,
     pub role: String,
-    pub age: usize,
-    pub current_damage: usize,
+    pub age: i32,
+    pub current_damage: i32,
     pub damage_notes: String,
     pub worn_armor: Vec<Uuid>,
     pub skills: Vec<Skill>,
@@ -106,12 +106,12 @@ impl fmt::Display for Attributes {
 /// `Character::effective_attribute()` which calculates the actual roll value.
 #[derive (Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AttributeValue {
-    pub base: usize,
-    pub actual: usize,
+    pub base: i32,
+    pub actual: i32,
 }
 
 impl AttributeValue {
-    pub fn new(actual: usize, base: usize) -> Self {
+    pub fn new(actual: i32, base: i32) -> Self {
         AttributeValue { base, actual }
     }
 }
@@ -126,16 +126,16 @@ impl Character {
     pub fn new(
         name: String,
         role: String,
-        age: usize,
-        att: usize,
-        mov: usize,
-        coo: usize,
-        emp: usize,
-        luck: usize,
-        int: usize,
-        body: usize,
-        refl: usize,
-        tec: usize,
+        age: i32,
+        att: i32,
+        mov: i32,
+        coo: i32,
+        emp: i32,
+        luck: i32,
+        int: i32,
+        body: i32,
+        refl: i32,
+        tec: i32,
     ) -> Self {
         let mut character = Character {
             name,
@@ -182,9 +182,9 @@ Character {{ \n\
 
     /// Body Type Modifier
     /// How much damage gets reduced when being hit, based on the body stat.
-    pub fn btm(&self) -> usize {
+    pub fn btm(&self) -> i32 {
         match self.attributes.get(&Attribute::Body).unwrap().actual {
-            0..=2 => 0,
+            ..=2 => 0,
             3..=4 => 1,
             5..=7 => 2,
             8..=9 => 3,
@@ -195,19 +195,21 @@ Character {{ \n\
 
     /// Returns the effective attribute value for dice rolls, including all
     /// temporary modifiers (encumbrance, drugs, combat effects, etc.).
-    pub fn effective_attribute(&self, attr: Attribute) -> usize {
+    pub fn effective_attribute(&self, attr: Attribute) -> i32 {
         let base_value = self.attributes[&attr].actual;
 
         match attr {
-            Attribute::Reflexes => base_value.saturating_sub(self.encumberance()
-                + self.calculate_armor_encumberance()),
-            Attribute::Move => base_value.saturating_sub(self.encumberance()),
-            _ => base_value
+            Attribute::Reflexes => (base_value
+                - self.encumberance()
+                - self.calculate_armor_encumberance())
+            .max(0),
+            Attribute::Move => (base_value - self.encumberance()).max(0),
+            _ => base_value,
         }
     }
 
     /// Calculates the malus to movement and reflexes based on encumberance
-    pub fn encumberance(&self) -> usize {
+    pub fn encumberance(&self) -> i32 {
         let inventory_weight = self.inventory.calculate_total_weight();
         let capacity = self.carry_capacity();
         match (inventory_weight*10) / capacity {
@@ -223,7 +225,7 @@ Character {{ \n\
     /// Looks up the carry capacity of the character
     /// Returns grams.
     pub fn carry_capacity(&self) -> usize {
-        self.attributes.get(&Attribute::Body).unwrap().actual * 10000
+        self.attributes.get(&Attribute::Body).unwrap().actual.max(0) as usize * 10000
     }
 
     /// Looks up the deadlift capacity of the character
@@ -259,7 +261,7 @@ Character {{ \n\
     ///
     /// This will apply damage to the armor (outer to inner) and then to the character.
     ///
-    pub fn hit(&mut self, damage: usize, zone: HitZone, damage_type: DamageType) {
+    pub fn hit(&mut self, damage: i32, zone: HitZone, damage_type: DamageType) {
         let mut remaining_damage = damage;
         let mut absorbed_damage = 0;
 
@@ -286,13 +288,10 @@ Character {{ \n\
 
     /// This ignores all armor and applies damage directly.
     /// It will subtract the BTM first.
-    pub fn take_damage(&mut self, damage: usize, zone: HitZone) {
+    pub fn take_damage(&mut self, damage: i32, zone: HitZone) {
         let mut remaining_damage = damage;
         if remaining_damage > 0 {
-            remaining_damage = remaining_damage.saturating_sub(self.btm());
-            if remaining_damage < 1 {
-                remaining_damage = 1;
-            }
+            remaining_damage = (remaining_damage - self.btm()).max(1);
 
             // TODO: Need to implement the House Rule that this doubling only takes effect after the check if it will kill you immediately.
             if zone == HitZone::Head {
@@ -316,7 +315,7 @@ Character {{ \n\
         }
     }
 
-    pub fn calculate_armor_encumberance(&self) -> usize {
+    pub fn calculate_armor_encumberance(&self) -> i32 {
         let mut encumberance = 0;
         let mut covered_zones = HashSet::new();
         for i in (0..self.worn_armor.len()).rev() {
@@ -367,8 +366,8 @@ Character {{ \n\
 pub struct Skill {
     pub name: String,
     pub base: Attribute,
-    pub level: usize,
-    pub level_up_modifier: usize,
+    pub level: i32,
+    pub level_up_modifier: i32,
 }
 
 impl Skill {
@@ -386,7 +385,7 @@ impl Skill {
         )
     }
 
-    pub fn new(name: String, base: Attribute, level: usize, level_up_modifierer: usize) -> Self {
+    pub fn new(name: String, base: Attribute, level: i32, level_up_modifierer: i32) -> Self {
         Skill {
             name,
             base,
@@ -579,9 +578,9 @@ mod tests {
         test_context: &str,
         armor_name: &str,
         hit_zone: HitZone,
-        expected_remaining_protection: usize,
+        expected_remaining_protection: i32,
         unhit_zone: HitZone,
-        expected_original_protection_in_unhit_zone: usize,
+        expected_original_protection_in_unhit_zone: i32,
     ) {
         let armor_list = character.inventory.get_all_armor();
         let armor = armor_list
@@ -608,7 +607,7 @@ mod tests {
         test_context: &str,
         armor_name: &str,
         hit_zone: HitZone,
-        expected_remaining_protection: usize,
+        expected_remaining_protection: i32,
         armor: &Armor,
     ) {
         let current_protection = armor.protection_current.get(&hit_zone);
@@ -782,7 +781,8 @@ mod tests {
         }
         assert_eq!(character.inventory.calculate_total_weight(), 160_900);
         assert_eq!(character.encumberance(), 8);
-        assert_eq!(character.effective_attribute(Attribute::Reflexes), basic_ref.saturating_sub(8));
+        // effective attributes never go below 0, even when the malus exceeds them
+        assert_eq!(character.effective_attribute(Attribute::Reflexes), (basic_ref - 8).max(0));
         assert_eq!(character.effective_attribute(Attribute::Move), 2);
     }
 }


### PR DESCRIPTION
Implements #18.

**Converted to `i32`:** attribute values (base/actual), age, current_damage, BTM, effective attributes, encumbrance maluses, skill levels, armor protection (max + per-zone), DamageResult, all damage parameters.

**Kept as `usize`:** `weight_grams`, `price_eb`, `amount`, carry capacity/deadlift (gram quantities that are never subtracted below zero — signedness would buy nothing there). Single cast point in `carry_capacity()`.

**Behavior notes:**
- `effective_attribute()` still clamps at 0 — an effective attribute below zero is meaningless for rolls; previously this came implicitly from `saturating_sub`, now it's an explicit `.max(0)`.
- `take_damage()` keeps the min-1-damage-after-BTM rule, now as `(damage - btm).max(1)`.
- `btm()` uses an open-ended `..=2` arm so a (theoretical) negative Body can't fall through to the `_ => 5` arm.

All 24 tests pass.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)