### PR TITLE
refactor: make item quantities i32 with explicit validation

### DIFF
--- a/AI-README.md
+++ b/AI-README.md
@@ -30,8 +30,16 @@ Mention situations where I mistype or misspell words / grammar.
 ## Non-Obvious Design Patterns
 
 ### Armor Damage Tracking (`armor.rs`)
-- `protection_max: usize` - Maximum stopping power (SP)
-- `protection_current: HashMap<HitZone, usize>` - Tracks per-zone degradation (WIP)
+- `protection_max: i32` - Maximum stopping power (SP)
+- `protection_current: BTreeMap<HitZone, i32>` - Tracks per-zone degradation (WIP)
+
+### Number Types (#18)
+- All game values are `i32` (attributes, damage, protection, encumbrance,
+  skill levels, amounts, weights, prices) — allows direct subtraction.
+- Non-negativity of `Item` quantities (`amount`, `weight_grams`, `price_eb`) is
+  enforced by explicit validation: `Item::new` panics with a meaningful message,
+  deserialization fails via `#[serde(try_from = "UncheckedItem")]`.
+- `effective_attribute()` clamps at 0; `take_damage` keeps the min-1-after-BTM rule.
 
 ### List Struct (`character.rs`)
 - `List(pub Vec<Skill>)` - Newtype wrapper for skill collections
@@ -87,8 +95,8 @@ Each damage type has a private helper method. Full mechanics documented on publi
 
 ### `Character.take_damage(damage, zone)` - IMPLEMENTED
 - Bypasses armor, applies damage directly to character
-- Applies Body Type Modifier (BTM) with minimum 1 damage rule (CP2020 RAW)
-- Uses `saturating_sub()` to prevent underflow when BTM > damage
+- Applies Body Type Modifier (BTM) with minimum 1 damage rule (CP2020 RAW),
+  implemented as `(damage - btm).max(1)`
 - **Head damage doubles** after BTM calculation
 - **Crippling damage** (8+ points after BTM):
   - **Critical zones (Head/Chest/Vitals)**: Instant death, sets `current_damage = 100`

--- a/src/armor.rs
+++ b/src/armor.rs
@@ -111,9 +111,9 @@ impl fmt::Display for Armor {
 impl Armor {
     pub fn new(
         name: String,
-        amount: usize,
-        weight_grams: usize,
-        price_eb: usize,
+        amount: i32,
+        weight_grams: i32,
+        price_eb: i32,
         comment: String,
         protection_max: i32,
         protected_zones: Vec<HitZone>,

--- a/src/character.rs
+++ b/src/character.rs
@@ -261,7 +261,7 @@ Character {{ \n\
         let inventory_weight = self.inventory.calculate_total_weight();
         let capacity = self.carry_capacity();
         match (inventory_weight * 10) / capacity {
-            0..=4 => 0,
+            ..=4 => 0,
             5..=6 => 1,
             7..=9 => 2,
             10..=12 => 4,
@@ -272,13 +272,13 @@ Character {{ \n\
 
     /// Looks up the carry capacity of the character
     /// Returns grams.
-    pub fn carry_capacity(&self) -> usize {
-        self.attributes.get(&Attribute::Body).unwrap().actual.max(0) as usize * 10000
+    pub fn carry_capacity(&self) -> i32 {
+        self.attributes.get(&Attribute::Body).unwrap().actual.max(0) * 10000
     }
 
     /// Looks up the deadlift capacity of the character
     /// Returns grams.
-    pub fn deadlift(&self) -> usize {
+    pub fn deadlift(&self) -> i32 {
         self.carry_capacity() * 4
     }
 

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,5 +1,6 @@
 use crate::armor::Armor;
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use std::fmt;
 use uuid::Uuid;
 
@@ -101,13 +102,54 @@ impl<'de> Deserialize<'de> for Inventory {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(try_from = "UncheckedItem")]
 pub struct Item {
     pub uuid: Uuid,
     pub name: String,
-    pub amount: usize,
-    pub weight_grams: usize,
-    pub price_eb: usize,
+    pub amount: i32,
+    pub weight_grams: i32,
+    pub price_eb: i32,
     pub comment: String,
+}
+
+/// Mirror of `Item` without validation, used as the deserialization input.
+/// `Item` itself can only be produced through `TryFrom`, which rejects
+/// negative quantities with a meaningful error message.
+#[derive(Deserialize)]
+struct UncheckedItem {
+    uuid: Uuid,
+    name: String,
+    amount: i32,
+    weight_grams: i32,
+    price_eb: i32,
+    comment: String,
+}
+
+impl TryFrom<UncheckedItem> for Item {
+    type Error = String;
+
+    fn try_from(raw: UncheckedItem) -> Result<Self, Self::Error> {
+        for (field, value) in [
+            ("amount", raw.amount),
+            ("weight_grams", raw.weight_grams),
+            ("price_eb", raw.price_eb),
+        ] {
+            if value < 0 {
+                return Err(format!(
+                    "Item '{}': {} must not be negative, got {}",
+                    raw.name, field, value
+                ));
+            }
+        }
+        Ok(Item {
+            uuid: raw.uuid,
+            name: raw.name,
+            amount: raw.amount,
+            weight_grams: raw.weight_grams,
+            price_eb: raw.price_eb,
+            comment: raw.comment,
+        })
+    }
 }
 
 impl InventoryItem for Item {
@@ -177,7 +219,7 @@ impl Inventory {
             .map(|item| &mut **item as &mut dyn InventoryItem)
     }
 
-    pub fn calculate_total_weight(&self) -> usize {
+    pub fn calculate_total_weight(&self) -> i32 {
         let mut total = 0;
         for item in &self.items {
             total += item.get_item().amount * item.get_item().weight_grams;
@@ -191,14 +233,32 @@ impl Inventory {
 }
 
 impl Item {
+    /// Creates a new item.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `amount`, `weight_grams` or `price_eb` is negative.
     pub fn new(
         uuid: Option<Uuid>,
         name: String,
-        amount: usize,
-        weight_grams: usize,
-        price_eb: usize,
+        amount: i32,
+        weight_grams: i32,
+        price_eb: i32,
         comment: String,
     ) -> Self {
+        for (field, value) in [
+            ("amount", amount),
+            ("weight_grams", weight_grams),
+            ("price_eb", price_eb),
+        ] {
+            assert!(
+                value >= 0,
+                "Item '{}': {} must not be negative, got {}",
+                name,
+                field,
+                value
+            );
+        }
         Item {
             uuid: uuid.unwrap_or(Uuid::new_v4()),
             name,
@@ -241,6 +301,34 @@ mod tests {
         let serialized = toml::to_string(&item).unwrap();
         let deserialized: Item = toml::from_str(&serialized).unwrap();
         assert_eq!(item, deserialized);
+    }
+
+    #[test]
+    #[should_panic(expected = "Item 'Broomstick': weight_grams must not be negative, got -1500")]
+    fn test_item_new_rejects_negative_weight() {
+        Item::new(
+            None,
+            "Broomstick".to_string(),
+            1,
+            -1500,
+            0,
+            "Test item".to_string(),
+        );
+    }
+
+    #[test]
+    fn test_item_deserialization_rejects_negative_amount() {
+        let toml_str = format!(
+            "uuid = \"{}\"\nname = \"Ammo 9mm\"\namount = -30\nweight_grams = 10\nprice_eb = 1\ncomment = \"\"\n",
+            Uuid::new_v4()
+        );
+        let result: Result<Item, _> = toml::from_str(&toml_str);
+        let error = result.unwrap_err().to_string();
+        assert!(
+            error.contains("Item 'Ammo 9mm': amount must not be negative, got -30"),
+            "unexpected error message: {}",
+            error
+        );
     }
 
     fn create_simple_inventory() -> Inventory {


### PR DESCRIPTION
Follow-up to #24 per Ben's ruling: `amount`, `weight_grams`, `price_eb` (and the derived `calculate_total_weight`, `carry_capacity`, `deadlift`) become `i32` too — amounts get subtracted (spent ammo), and `amount * weight_grams` products would otherwise need casts everywhere. This removes the last usize↔i32 cast in the codebase.

The non-negativity guarantee that `usize` gave implicitly is now **explicit validation with meaningful errors**:
- `Item::new` panics with e.g. `Item 'Broomstick': weight_grams must not be negative, got -1500`
- Loading a TOML file with negative quantities fails cleanly via `#[serde(try_from = "UncheckedItem")]` instead of constructing invalid state

Two new tests cover both paths (26 total, all passing).

Stacked on #25 → merge order: #24, #25, then this one (GitHub retargets automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)