### PR TITLE
feat: dice engine with house rules (M1, #11)

### DIFF
--- a/AI-README.md
+++ b/AI-README.md
@@ -149,11 +149,14 @@ Encumbrance affects:
 - `Character::check_skill(name, ...)` -> `Result` (error on unknown skill),
   uses `effective_attribute` so encumbrance maluses apply automatically.
   `Character::check_attribute(...)` for untrained rolls.
-- **Luck pool**: `Character.current_luck` is persistent (survives sessions).
+- **Luck, three levels**: starting base (`AttributeValue.base`, chargen value,
+  never changes) / current base (`AttributeValue.actual`, permanently reducible
+  via `Character::sacrifice_luck` for world-turning events; regen rate + cap) /
+  current pool (`Character.current_luck`, persistent across sessions).
   Committed luck is deducted by check_skill/check_attribute (also on
   auto-success); overspending errors without rolling.
-  `Character::start_session()` regenerates ceil(base LUCK / 2), capped at the
-  LUCK attribute.
+  `Character::start_session()` regenerates ceil(current base / 2), capped at
+  the current base.
 - `Difficulty::{Easy=10, Normal=15, Hard=20, Custom(n)}`.
 
 ---

--- a/AI-README.md
+++ b/AI-README.md
@@ -149,7 +149,11 @@ Encumbrance affects:
 - `Character::check_skill(name, ...)` -> `Result` (error on unknown skill),
   uses `effective_attribute` so encumbrance maluses apply automatically.
   `Character::check_attribute(...)` for untrained rolls.
-- Per-evening luck budget is NOT enforced yet (session state, later milestone).
+- **Luck pool**: `Character.current_luck` is persistent (survives sessions).
+  Committed luck is deducted by check_skill/check_attribute (also on
+  auto-success); overspending errors without rolling.
+  `Character::start_session()` regenerates ceil(base LUCK / 2), capped at the
+  LUCK attribute.
 - `Difficulty::{Easy=10, Normal=15, Hard=20, Custom(n)}`.
 
 ---

--- a/AI-README.md
+++ b/AI-README.md
@@ -136,11 +136,30 @@ Encumbrance affects:
 
 ---
 
+## Dice Engine (`dice.rs`) — #11
+
+- All rolls go through the `DieRoller` trait: `RandomRoller` (rand crate) in
+  play, `SequenceRoller` (scripted values) in tests and for future replay.
+- `skill_check(attribute, skill, luck, difficulty, roller)` implements the
+  house rules: auto-success when attribute+skill+luck ≥ target (no roll),
+  exploding 10s (cascade), fumble on 1 with confirmation die (1 critical,
+  2-5 embarrassing, 6-10 normal failure), luck modifies the first die
+  directly (9+1 luck = natural 10 and explodes; 1+luck = no fumble).
+- `open_roll(...)` = same mechanics without a target.
+- `Character::check_skill(name, ...)` -> `Result` (error on unknown skill),
+  uses `effective_attribute` so encumbrance maluses apply automatically.
+  `Character::check_attribute(...)` for untrained rolls.
+- Per-evening luck budget is NOT enforced yet (session state, later milestone).
+- `Difficulty::{Easy=10, Normal=15, Hard=20, Custom(n)}`.
+
+---
+
 ## Quick Reference
 
 | What | Where |
 |------|-------|
 | Character stats | `character.rs` → `Character`, `Attribute` |
 | Skills | `character.rs` → `Skill`, `List` |
+| Dice & checks | `dice.rs` → `skill_check`, `open_roll`, `DieRoller`, `Difficulty` |
 | Inventory system | `inventory.rs` → `Inventory`, `Item`, `InventoryItem` |
 | Armor & hit zones | `armor.rs` → `Armor`, `HitZone` |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ uuid = { version = "1.19", features = ["v4", "serde"] }
 serde = { version = "1.0.118", features = ["derive"] }
 toml = "0.5.8"
 serde_with = "1.6.0"
+rand = "0.10.2"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -4,12 +4,5 @@ Standing Q&A file: Claude collects questions here so Ben can answer them in one
 go; answered questions are folded into PROJECT-STRUCTURE.md (marked *(decided)*)
 and removed.
 
-**Q16 — Luck vs. fumble and explosion (dice engine, M1).** The wiki says luck
-points modify the die directly ("eine gewürfelte 9 und ein Glückspunkt zählen
-als natürliche 10"), which I implemented symmetrically:
-- a rolled 9 + 1 luck counts as a natural 10 and **explodes** (re-roll and add), and
-- a rolled 1 + luck counts as 2+, so it is **not a fumble**.
-
-Is the symmetric reading correct — can players buy their way out of a botch
-with a pre-committed luck point? (Implemented this way in `dice.rs`; easy to
-change if not.)
+**No open questions right now.** (Q1–Q16 answered; decisions live in
+PROJECT-STRUCTURE.md, section 3.)

--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -4,5 +4,12 @@ Standing Q&A file: Claude collects questions here so Ben can answer them in one
 go; answered questions are folded into PROJECT-STRUCTURE.md (marked *(decided)*)
 and removed.
 
-**No open questions right now.** (All questions from 2026-07-09 were answered
-and their decisions are recorded in PROJECT-STRUCTURE.md, section 3.)
+**Q16 — Luck vs. fumble and explosion (dice engine, M1).** The wiki says luck
+points modify the die directly ("eine gewürfelte 9 und ein Glückspunkt zählen
+als natürliche 10"), which I implemented symmetrically:
+- a rolled 9 + 1 luck counts as a natural 10 and **explodes** (re-roll and add), and
+- a rolled 1 + luck counts as 2+, so it is **not a fumble**.
+
+Is the symmetric reading correct — can players buy their way out of a botch
+with a pre-committed luck point? (Implemented this way in `dice.rs`; easy to
+change if not.)

--- a/PROJECT-STRUCTURE.md
+++ b/PROJECT-STRUCTURE.md
@@ -106,8 +106,13 @@ Design rules already established (keep them):
   dropped — the table forgot it and doesn't play it.)*
 - **Fumble**: natural 1 = failure; roll again: 1 = critical failure (harm own side),
   2–5 = embarrassing failure, 6–0 = normal failure.
-- **Luck**: points committed *before* the roll modify the die directly (9 + 1 luck
-  counts as a natural 10). Max luck spent per game evening = LUCK attribute.
+- **Luck**: points committed *before* the roll modify the die directly.
+  *(decided)*: symmetric reading — 9 + 1 luck counts as a natural 10 and
+  explodes; 1 + 1 luck counts as 2 and is no fumble.
+- **Luck budget** *(decided, replaces the old per-evening reset)*: luck points
+  are a persistent per-character pool. Each new session regenerates
+  ceil(base LUCK / 2) points, capped at the LUCK attribute. Example: base LUCK 9,
+  8 spent (1 left) → next session +5 → starts with 6.
 - **Multiple actions**: each extra action per round → −3 on all actions.
 
 ### Damage & health (`health.rs`, `character.rs`) — for #13/#19

--- a/PROJECT-STRUCTURE.md
+++ b/PROJECT-STRUCTURE.md
@@ -109,10 +109,17 @@ Design rules already established (keep them):
 - **Luck**: points committed *before* the roll modify the die directly.
   *(decided)*: symmetric reading — 9 + 1 luck counts as a natural 10 and
   explodes; 1 + 1 luck counts as 2 and is no fumble.
-- **Luck budget** *(decided, replaces the old per-evening reset)*: luck points
-  are a persistent per-character pool. Each new session regenerates
-  ceil(base LUCK / 2) points, capped at the LUCK attribute. Example: base LUCK 9,
-  8 spent (1 left) → next session +5 → starts with 6.
+- **Luck budget** *(decided, replaces the old per-evening reset)*: luck has
+  three levels:
+  1. *Starting base* — the chargen value, never changes (`AttributeValue.base`).
+  2. *Current base* — permanently reducible for extreme "the world now turns in
+     your favor" events; regeneration rate and cap derive from it
+     (`AttributeValue.actual`, `Character::sacrifice_luck`).
+  3. *Current pool* — fluctuates with every roll (`Character.current_luck`).
+
+  Each new session regenerates ceil(current base / 2) points, capped at the
+  current base. Example: current base 9, 8 spent (1 left) → next session +5 →
+  starts with 6.
 - **Multiple actions**: each extra action per round → −3 on all actions.
 
 ### Damage & health (`health.rs`, `character.rs`) — for #13/#19

--- a/docs/rules/Regeln.wiki
+++ b/docs/rules/Regeln.wiki
@@ -13,8 +13,14 @@ Würfelt man eine 10 addiert man diese und es wird weiter gewürfelt bis man kei
 Ein Wurf von 1 ist ein Fehlschlag, danach wird nochmal gewürfelt; 1: Kritischer Fehler, Schaden am eigenen Team / sich selbst. 2-5: Fehlschlag und sieht peinlich aus. 6-0: Normaler Fehlschlag.
 
 ===Glück===
-Man kann seinen Wurf modifizieren in dem man VOR dem Wurf Glückspunkte einsetzt. Diese verändern den Wurf direkt, d.H. Eine gewürfelte 9 und ein Glückspunkte zählen als natürliche 10.
-Man darf pro Spielabend nicht mehr Glückspunkte ausgeben als man LUCK hat. Weitere Würfe auf LUCK an diesem Abend sind entsprechend modifiziert.
+Glückspunkte werden VOR dem Wurf eingesetzt und verändern den Würfel direkt: eine gewürfelte 9 mit einem Glückspunkt zählt als natürliche 10 (und kaskadiert), eine gewürfelte 1 mit einem Glückspunkt zählt als 2 und ist kein Patzer.
+
+Glück hat drei Ebenen:
+# '''Start-Basis''': der Wert aus der Charaktererschaffung, ändert sich nie.
+# '''Aktuelle Basis''': kann für extreme „Die Welt dreht sich jetzt zu deinen Gunsten“-Ereignisse dauerhaft gesenkt werden. Regeneration und Obergrenze richten sich nach diesem Wert.
+# '''Aktueller Pool''': schwankt mit jedem Einsatz und bleibt über Sitzungen erhalten.
+
+Zu Beginn jeder Sitzung regeneriert der Pool die Hälfte der aktuellen Basis (aufgerundet), maximal bis zur aktuellen Basis. Beispiel: Basis 9, davon 8 ausgegeben (1 übrig) → nächste Sitzung +5 → Start mit 6.
 
 ===Mehrere Aktionen===
 Man kann weitere Aktionen pro Runde ausführen mit jeweils -3 auf alle.
@@ -69,7 +75,7 @@ gewürfelt. Soviel extra Schaden kann dieser Schuss noch anrichten bevor
 es ein Durchschuss wird.
 
 ====Mehr als 8 Schaden====
-Wenn in einem Treffer mehr als 8 Punkte Schaden auf einmal in einem Körperteil ankommen muss man einen Wurf BODY gegen 10+(Wundschaden-10) machen. Misslingt dieser ist der Körperteil kaputt. Kopf und Torso Treffer sind ab dann sofort tödlich.
+Kommen in einem Treffer mehr als 8 Punkte Schaden (nach BTM) in einem Körperteil an, ist das Körperteil zerstört. Kopf-, Brust- und Vitals-Treffer sind dann sofort tödlich; bei anderen Zonen ist man ab sofort mindestens Mortal 0 (13 Schaden) und dabei zu sterben.
 
 ====Kopftreffer====
 Kopftreffer machen immer doppelten Schaden. Das mehr als 8 Limit gilt aber gegen den unmodifizierten Schaden.

--- a/docs/rules/Technlogien.wiki
+++ b/docs/rules/Technlogien.wiki
@@ -61,7 +61,7 @@ Die Waffen werden irgendwo westlich an der Transsib hergestellt und kommen über
 === AK-47 ===
 Eine zuverlässige stabile Waffe die es wohl schon immer gab. Sie verwendet Munition im 7,62 x 39 mm. Werte:
 * Gewehr
-* 6D6+2 Schaden, Panzerbrechend. ( Schutzwert wird halbiert, Schaden auch, ab 8 Schadenspunkten wird von einem Durchschlag ausgegangen)
+* 5D6 Schaden, Panzerbrechend (Schutzwert wird halbiert, Schaden gegen weiche Ziele auch). Die 6D6+2-Variante ist die Czar AK-47 aus CP2020 Reference Book 5.
 * Reichweite 300 Meter
 * Sehr zuverlässig
 * Nicht versteckbar

--- a/docs/rules/hausregeln.wiki
+++ b/docs/rules/hausregeln.wiki
@@ -33,18 +33,52 @@ Vor- und Nachteile aus Gurps, siehe [[VorUndNachteile]].
 
 Ausdauer und Prellschaden. Jeder hat 5 Prellpunkte. Anstrengende Arbeiten, Treffer die von weicher Rüstung gefangen werden und ähnliches gehen auf diese Skala. Ist die Skala bei 0 gibt es einen Schaden und sie beginnt wieder bei 5 zu zählen. Wenn man Schaden nimmt der nur Prellschaden ist, erhält man diese Menge Abzug auf seinen nächsten Wurf (muss aber keinen KO Check machen). Wird der Prellschaden zu echtem Schaden bekommt man keinen Abzug, muss aber einen KO Check machen.
 
+Prellschaden entsteht nur durch Treffer, die von WEICHER Rüstung gefangen werden (und durch anstrengende Arbeiten etc.). Von harter Rüstung absorbierter Schaden erzeugt keinen Prellschaden.
+
+Der Body Type Modifier (BTM) wird vom ankommenden Schaden abgezogen und in Prellschaden umgewandelt (Minimum 1 echter Schaden bleibt). Nahkampfwaffen und Kampfkunst benutzen beim Austeilen den davon verschiedenen Schadensmodifikator „DAM“.
+
 Wenn eine Schusswaffe mehr als 4 Punkte Schaden macht wird mit 1d10 gewürfelt. Soviel extra Schaden kann dieser Schuss noch anrichten bevor es ein Durchschuss wird.
 
 Eine Verletzung vom Typ "Kritisch" oder darüber hat eine 5% Chance auf Verkrüppelung des entsprechenden Körperteils wenn nicht besondere Medizinische Hilfe geleistet wird. (5/1000 wenn diese geleistet wird).
 
 Kopftrefferschaden wird verdoppelt, aber die Frage ob man daran stirbt ist verändert. Siehe [[Regeln]].
 
+== Traglast ==
+Tragekapazität = BODY × 10 kg. Deadlift = das Vierfache davon.
+
+Abzug auf Reflexe und Move nach dem Verhältnis Inventargewicht / Kapazität:
+{| class="wikitable"
+! Verhältnis !! Abzug
+|-
+| unter 0,5 || 0
+|-
+| 0,5 bis unter 0,7 || −1
+|-
+| 0,7 bis unter 1,0 || −2
+|-
+| 1,0 bis unter 1,3 || −4
+|-
+| 1,3 bis unter 1,6 || −6
+|-
+| ab 1,6 || −8
+|}
+Reflexe werden zusätzlich um die Behinderung der getragenen Rüstung reduziert, Move nur um die Inventar-Behinderung.
+
 == Würfel ==
 Ist der Minimalwert (also Attribut + Fertigkeit + eingesetztes Glück) größer als die Zielvorgabe wird nicht gewürfelt, automatischer Erfolg, immer (auch im Kampf).
 
 Ein Wurf von 1 ist ein Fehlschlag, danach wird nochmal gewürfelt; 1: Kritischer Fehler, Schaden am eigenen Team / sich selbst. 2-5: Fehlschlag und sieht peinlich aus. 6-0: Normaler Fehlschlag
 
-Ein Wurf von 10 ist eine besondere Leistung in dieser Fertigkeit. Ein CP für diese Fertigkeit und nochmal würfeln und dazu zählen (kaskadiert).
+Ein Wurf von 10 ist eine besondere Leistung: nochmal würfeln und dazu zählen (kaskadiert).
+=== Glück ===
+Glückspunkte werden VOR dem Wurf eingesetzt und verändern den Würfel direkt: eine gewürfelte 9 mit einem Glückspunkt zählt als natürliche 10 (und kaskadiert), eine gewürfelte 1 mit einem Glückspunkt zählt als 2 und ist kein Patzer.
+
+Glück hat drei Ebenen:
+# '''Start-Basis''': der Wert aus der Charaktererschaffung, ändert sich nie.
+# '''Aktuelle Basis''': kann für extreme „Die Welt dreht sich jetzt zu deinen Gunsten“-Ereignisse dauerhaft gesenkt werden. Regeneration und Obergrenze richten sich nach diesem Wert.
+# '''Aktueller Pool''': schwankt mit jedem Einsatz und bleibt über Sitzungen erhalten.
+
+Zu Beginn jeder Sitzung regeneriert der Pool die Hälfte der aktuellen Basis (aufgerundet), maximal bis zur aktuellen Basis. Beispiel: Basis 9, davon 8 ausgegeben (1 übrig) → nächste Sitzung +5 → Start mit 6.
 ==Schalldämpfer und Lärm eines Schuss==
 Schusswaffen sind laut. Sehr Laut. Das liegt an zwei Elementen: Eine fette Explosion und ein Projektil, das die Schallmauer durchbricht. Wenn ich also einen Schalldämpfer benutze, muss ich mir aus taktischer Sicht bewusst sein, dass er die Waffe nicht leise macht.
 

--- a/docs/rules/wiki-update-drafts.md
+++ b/docs/rules/wiki-update-drafts.md
@@ -1,5 +1,12 @@
 # Wiki-Update-Entwürfe
 
+> **Status: ANGEWENDET am 2026-07-09** (Bot-Account „Morast“ via
+> `tools/fandom.py`). Punkte 1–5 wie unten; Punkt 6 bewusst konservativer:
+> nur der Schadens-Bullet wurde geändert (5D6 + Czar-Hinweis), Reichweite
+> 300 m und 1/15 Schuss blieben unangetastet, weil sie von Ben stammen
+> könnten. Die Snapshots in diesem Ordner sind auf dem neuen Stand.
+> Datei bleibt als Vorlage für künftige Regel-Synchronisierungen.
+
 Fertige Wikitext-Schnipsel für desaster.fandom.com, damit das Wiki wieder mit
 den entschiedenen Regeln (PROJECT-STRUCTURE.md §3, Stand 2026-07-09)
 übereinstimmt. Pro Abschnitt: Seite, was ersetzt wird, neuer Text.

--- a/docs/rules/wiki-update-drafts.md
+++ b/docs/rules/wiki-update-drafts.md
@@ -1,0 +1,113 @@
+# Wiki-Update-Entwürfe
+
+Fertige Wikitext-Schnipsel für desaster.fandom.com, damit das Wiki wieder mit
+den entschiedenen Regeln (PROJECT-STRUCTURE.md §3, Stand 2026-07-09)
+übereinstimmt. Pro Abschnitt: Seite, was ersetzt wird, neuer Text.
+
+---
+
+## 1. Seite `Hausregeln`, Abschnitt `== Würfel ==`
+
+**Ersetzt:** den Satz „Ein Wurf von 10 ist eine besondere Leistung in dieser
+Fertigkeit. Ein CP für diese Fertigkeit und nochmal würfeln und dazu zählen
+(kaskadiert)." — die CP-Regel ist entfallen (wird am Tisch nicht gespielt).
+
+```
+Ein Wurf von 10 ist eine besondere Leistung: nochmal würfeln und dazu zählen (kaskadiert).
+```
+
+**Neu anfügen (Glück, drei Ebenen + Regeneration):**
+
+```
+=== Glück ===
+Glückspunkte werden VOR dem Wurf eingesetzt und verändern den Würfel direkt: eine gewürfelte 9 mit einem Glückspunkt zählt als natürliche 10 (und kaskadiert), eine gewürfelte 1 mit einem Glückspunkt zählt als 2 und ist kein Patzer.
+
+Glück hat drei Ebenen:
+# '''Start-Basis''': der Wert aus der Charaktererschaffung, ändert sich nie.
+# '''Aktuelle Basis''': kann für extreme „Die Welt dreht sich jetzt zu deinen Gunsten"-Ereignisse dauerhaft gesenkt werden. Regeneration und Obergrenze richten sich nach diesem Wert.
+# '''Aktueller Pool''': schwankt mit jedem Einsatz und bleibt über Sitzungen erhalten.
+
+Zu Beginn jeder Sitzung regeneriert der Pool die Hälfte der aktuellen Basis (aufgerundet), maximal bis zur aktuellen Basis. Beispiel: Basis 9, davon 8 ausgegeben (1 übrig) → nächste Sitzung +5 → Start mit 6.
+```
+
+---
+
+## 2. Seite `Hausregeln`, Abschnitt `== Schaden ==`
+
+**Ergänzen beim Prellschaden-Absatz (Klarstellung harte Rüstung):**
+
+```
+Prellschaden entsteht nur durch Treffer, die von WEICHER Rüstung gefangen werden (und durch anstrengende Arbeiten etc.). Von harter Rüstung absorbierter Schaden erzeugt keinen Prellschaden.
+
+Der Body Type Modifier (BTM) wird vom ankommenden Schaden abgezogen und in Prellschaden umgewandelt (Minimum 1 echter Schaden bleibt). Nahkampfwaffen und Kampfkunst benutzen beim Austeilen den davon verschiedenen Schadensmodifikator „DAM".
+```
+
+---
+
+## 3. Seite `Hausregeln`, neuer Abschnitt `== Traglast ==`
+
+**Neu (Tabelle war bisher nur im Code, Entscheidung Q4: Code ist richtig):**
+
+```
+== Traglast ==
+Tragekapazität = BODY × 10 kg. Deadlift = das Vierfache davon.
+
+Abzug auf Reflexe und Move nach dem Verhältnis Inventargewicht / Kapazität:
+{| class="wikitable"
+! Verhältnis !! Abzug
+|-
+| unter 0,5 || 0
+|-
+| 0,5 bis unter 0,7 || −1
+|-
+| 0,7 bis unter 1,0 || −2
+|-
+| 1,0 bis unter 1,3 || −4
+|-
+| 1,3 bis unter 1,6 || −6
+|-
+| ab 1,6 || −8
+|}
+Reflexe werden zusätzlich um die Behinderung der getragenen Rüstung reduziert, Move nur um die Inventar-Behinderung.
+```
+
+---
+
+## 4. Seite `Regeln`, Abschnitt `==== Mehr als 8 Schaden ====`
+
+**Ersetzt:** den BODY-Wurf-Text (obsolet, Entscheidung Q6: der Code ist richtig).
+
+```
+==== Mehr als 8 Schaden ====
+Kommen in einem Treffer mehr als 8 Punkte Schaden (nach BTM) in einem Körperteil an, ist das Körperteil zerstört. Kopf-, Brust- und Vitals-Treffer sind dann sofort tödlich; bei anderen Zonen ist man ab sofort mindestens Mortal 0 (13 Schaden) und dabei zu sterben.
+```
+
+---
+
+## 5. Seite `Regeln`, Abschnitt `=== Glück ===`
+
+**Ersetzt:** „Man darf pro Spielabend nicht mehr Glückspunkte ausgeben als man
+LUCK hat. …" durch den Drei-Ebenen-Text aus Punkt 1 (gleicher Wortlaut).
+
+---
+
+## 6. Seite `Technlogien`, Abschnitt `=== AK-47 ===`
+
+**Korrektur:** 6d6+2 gehört zur Czar AK-47 / Kalashnikov A-80; die klassische
+AK-47 hat laut CP2020 Reference Book 5 (und am Tisch gespielt) 5d6.
+
+```
+* Gewehr
+* 5D6 Schaden (7,62 × 39 mm). Mit panzerbrechender Munition: Schutzwert wird halbiert, Schaden gegen weiche Ziele auch.
+* Reichweite 400 Meter
+* Magazin 30 Schuss, bis zu 20 Schuss pro Runde (Autofeuer)
+* Sehr zuverlässig
+* Nicht versteckbar
+```
+
+(Hinweis: „ab 8 Schadenspunkten wird von einem Durchschlag ausgegangen" im
+alten Text vermischt die Durchschuss-Regel — die steht allgemein unter
+[[Regeln]], Durchschlag bei Schusswaffen, und gehört nicht zur Waffe.)
+
+(Tippfehler nebenbei: Seitenname „Technlogien" → „Technologien",
+„hypotetisch" → „hypothetisch".)

--- a/src/character.rs
+++ b/src/character.rs
@@ -14,6 +14,9 @@ pub struct Character {
     pub role: String,
     pub age: i32,
     pub current_damage: i32,
+    /// Available luck points. A persistent pool: spending survives the session,
+    /// [`Character::start_session`] regenerates half the base LUCK (rounded up).
+    pub current_luck: i32,
     pub damage_notes: String,
     pub worn_armor: Vec<Uuid>,
     pub skills: Vec<Skill>,
@@ -145,6 +148,7 @@ impl Character {
             inventory: Inventory::new(),
             worn_armor: Vec::new(),
             current_damage: 0,
+            current_luck: luck,
             damage_notes: "".to_string(),
             skills: Vec::new(),
         };
@@ -397,18 +401,50 @@ Character {{ \n\
         armor
     }
 
+    /// Spends luck points from the character's pool.
+    ///
+    /// Returns an error when the pool doesn't cover it (or `points` is negative);
+    /// the pool is unchanged in that case.
+    pub fn spend_luck(&mut self, points: i32) -> Result<(), String> {
+        if points < 0 {
+            return Err(format!(
+                "Cannot spend a negative amount of luck: {}",
+                points
+            ));
+        }
+        if points > self.current_luck {
+            return Err(format!(
+                "Character '{}' has only {} luck points, tried to spend {}",
+                self.name, self.current_luck, points
+            ));
+        }
+        self.current_luck -= points;
+        Ok(())
+    }
+
+    /// Starts a new game session: regenerates half the base LUCK (rounded up),
+    /// capped at the LUCK attribute's current value.
+    ///
+    /// Example: base LUCK 9, 8 already spent (1 left) → +5 → starts with 6.
+    pub fn start_session(&mut self) {
+        let luck = self.attributes.get(&Attribute::Luck).unwrap();
+        let regenerated = (luck.base + 1) / 2;
+        self.current_luck = (self.current_luck + regenerated).min(luck.actual);
+    }
+
     /// Rolls a check on one of the character's skills.
     ///
     /// Uses the effective base attribute (encumbrance and other temporary
     /// maluses included) plus the skill level. `luck` is the number of luck
-    /// points the player commits before the roll; enforcing the per-evening
-    /// luck budget is not handled here yet.
+    /// points the player commits before the roll; they are deducted from
+    /// [`Character::current_luck`] (also on an auto-success — committed is
+    /// committed) and the check fails with an error if the pool is too small.
     ///
     /// Returns an error naming the skill if the character doesn't have it —
     /// rolling untrained is a deliberate decision, not a fallback:
     /// use [`Character::check_attribute`] for that.
     pub fn check_skill(
-        &self,
+        &mut self,
         skill_name: &str,
         luck: i32,
         difficulty: Difficulty,
@@ -424,10 +460,11 @@ Character {{ \n\
                     self.name, skill_name
                 )
             })?;
-        let attribute = self.effective_attribute(skill.base);
+        let (attribute_value, skill_level) = (self.effective_attribute(skill.base), skill.level);
+        self.spend_luck(luck)?;
         Ok(skill_check(
-            attribute,
-            skill.level,
+            attribute_value,
+            skill_level,
             luck,
             difficulty,
             roller,
@@ -435,20 +472,17 @@ Character {{ \n\
     }
 
     /// Rolls a check on a bare attribute (untrained, skill level 0).
+    /// Committed luck is deducted like in [`Character::check_skill`].
     pub fn check_attribute(
-        &self,
+        &mut self,
         attribute: Attribute,
         luck: i32,
         difficulty: Difficulty,
         roller: &mut dyn DieRoller,
-    ) -> CheckResult {
-        skill_check(
-            self.effective_attribute(attribute),
-            0,
-            luck,
-            difficulty,
-            roller,
-        )
+    ) -> Result<CheckResult, String> {
+        let attribute_value = self.effective_attribute(attribute);
+        self.spend_luck(luck)?;
+        Ok(skill_check(attribute_value, 0, luck, difficulty, roller))
     }
 
     pub fn print_skills(&self) {
@@ -849,7 +883,7 @@ mod tests {
 
     #[test]
     fn test_check_skill_uses_attribute_and_level() {
-        let character = unencumbered_shooter();
+        let mut character = unencumbered_shooter();
         let mut roller = crate::dice::SequenceRoller::new(vec![3]);
         let result = character
             .check_skill("Pistole", 0, Difficulty::Normal, &mut roller)
@@ -861,7 +895,7 @@ mod tests {
 
     #[test]
     fn test_check_skill_unknown_skill_errors() {
-        let character = unencumbered_shooter();
+        let mut character = unencumbered_shooter();
         let mut roller = crate::dice::SequenceRoller::new(vec![]);
         let error = character
             .check_skill(
@@ -875,6 +909,49 @@ mod tests {
             error,
             "Character 'Shooter' has no skill named 'Unterwasserkorbflechten'"
         );
+    }
+
+    #[test]
+    fn test_check_skill_spends_committed_luck() {
+        let mut character = unencumbered_shooter();
+        assert_eq!(character.current_luck, 5);
+        let mut roller = crate::dice::SequenceRoller::new(vec![3]);
+        character
+            .check_skill("Pistole", 2, Difficulty::Hard, &mut roller)
+            .unwrap();
+        assert_eq!(character.current_luck, 3);
+    }
+
+    #[test]
+    fn test_check_skill_rejects_overspent_luck() {
+        let mut character = unencumbered_shooter();
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let error = character
+            .check_skill("Pistole", 6, Difficulty::Normal, &mut roller)
+            .unwrap_err();
+        assert_eq!(
+            error,
+            "Character 'Shooter' has only 5 luck points, tried to spend 6"
+        );
+        assert_eq!(character.current_luck, 5);
+    }
+
+    #[test]
+    fn test_start_session_regenerates_half_base_luck() {
+        let mut character = unencumbered_shooter();
+        // change base LUCK to 9 to mirror the example from the table rules
+        character
+            .attributes
+            .insert(Attribute::Luck, AttributeValue::new(9, 9));
+        character.current_luck = 1;
+        character.start_session();
+        // 1 + ceil(9/2) = 6
+        assert_eq!(character.current_luck, 6);
+
+        // regeneration is capped at the LUCK attribute
+        character.current_luck = 8;
+        character.start_session();
+        assert_eq!(character.current_luck, 9);
     }
 
     #[test]
@@ -900,10 +977,11 @@ mod tests {
 
     #[test]
     fn test_check_attribute_auto_success() {
-        let character = unencumbered_shooter();
+        let mut character = unencumbered_shooter();
         let mut roller = crate::dice::SequenceRoller::new(vec![]);
-        let result =
-            character.check_attribute(Attribute::Body, 0, Difficulty::Custom(10), &mut roller);
+        let result = character
+            .check_attribute(Attribute::Body, 0, Difficulty::Custom(10), &mut roller)
+            .unwrap();
         assert_eq!(result.outcome, crate::dice::Outcome::AutoSuccess);
     }
 

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,3 +1,4 @@
+use crate::dice::{skill_check, CheckResult, DieRoller, Difficulty};
 use crate::{armor::HitZone, Armor};
 use crate::{inventory::Inventory, DamageType};
 use serde::{Deserialize, Serialize};
@@ -396,6 +397,60 @@ Character {{ \n\
         armor
     }
 
+    /// Rolls a check on one of the character's skills.
+    ///
+    /// Uses the effective base attribute (encumbrance and other temporary
+    /// maluses included) plus the skill level. `luck` is the number of luck
+    /// points the player commits before the roll; enforcing the per-evening
+    /// luck budget is not handled here yet.
+    ///
+    /// Returns an error naming the skill if the character doesn't have it —
+    /// rolling untrained is a deliberate decision, not a fallback:
+    /// use [`Character::check_attribute`] for that.
+    pub fn check_skill(
+        &self,
+        skill_name: &str,
+        luck: i32,
+        difficulty: Difficulty,
+        roller: &mut dyn DieRoller,
+    ) -> Result<CheckResult, String> {
+        let skill = self
+            .skills
+            .iter()
+            .find(|skill| skill.name == skill_name)
+            .ok_or_else(|| {
+                format!(
+                    "Character '{}' has no skill named '{}'",
+                    self.name, skill_name
+                )
+            })?;
+        let attribute = self.effective_attribute(skill.base);
+        Ok(skill_check(
+            attribute,
+            skill.level,
+            luck,
+            difficulty,
+            roller,
+        ))
+    }
+
+    /// Rolls a check on a bare attribute (untrained, skill level 0).
+    pub fn check_attribute(
+        &self,
+        attribute: Attribute,
+        luck: i32,
+        difficulty: Difficulty,
+        roller: &mut dyn DieRoller,
+    ) -> CheckResult {
+        skill_check(
+            self.effective_attribute(attribute),
+            0,
+            luck,
+            difficulty,
+            roller,
+        )
+    }
+
     pub fn print_skills(&self) {
         println!("Skills:");
         for skill in &self.skills {
@@ -476,6 +531,7 @@ impl fmt::Display for List {
 mod tests {
     use super::*;
     use crate::armor::tests::*;
+    use crate::inventory::Item;
     use toml;
 
     fn populated_character() -> Character {
@@ -768,6 +824,87 @@ mod tests {
             "character serialization round-trip didn't work {}",
             character
         );
+    }
+
+    fn unencumbered_shooter() -> Character {
+        let mut character = Character::new(
+            "Shooter".to_string(),
+            "Solo".to_string(),
+            25,
+            5,
+            6,
+            5,
+            5,
+            5,
+            5,
+            10,
+            8,
+            5,
+        );
+        character
+            .skills
+            .push(Skill::new("Pistole".to_string(), Attribute::Reflexes, 4, 1));
+        character
+    }
+
+    #[test]
+    fn test_check_skill_uses_attribute_and_level() {
+        let character = unencumbered_shooter();
+        let mut roller = crate::dice::SequenceRoller::new(vec![3]);
+        let result = character
+            .check_skill("Pistole", 0, Difficulty::Normal, &mut roller)
+            .unwrap();
+        // REF 8 + Pistole 4 + die 3 = 15
+        assert_eq!(result.total, 15);
+        assert!(result.outcome.is_success());
+    }
+
+    #[test]
+    fn test_check_skill_unknown_skill_errors() {
+        let character = unencumbered_shooter();
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let error = character
+            .check_skill(
+                "Unterwasserkorbflechten",
+                0,
+                Difficulty::Normal,
+                &mut roller,
+            )
+            .unwrap_err();
+        assert_eq!(
+            error,
+            "Character 'Shooter' has no skill named 'Unterwasserkorbflechten'"
+        );
+    }
+
+    #[test]
+    fn test_check_skill_applies_encumbrance_malus() {
+        let mut character = unencumbered_shooter();
+        // Body 10 -> capacity 100kg; 50kg load -> encumbrance malus 1 on REF.
+        character.inventory.push(Box::new(Item::new(
+            None,
+            "Schrottkiste".to_string(),
+            1,
+            50_000,
+            0,
+            "heavy junk".to_string(),
+        )));
+        let mut roller = crate::dice::SequenceRoller::new(vec![3]);
+        let result = character
+            .check_skill("Pistole", 0, Difficulty::Normal, &mut roller)
+            .unwrap();
+        // effective REF 7 + Pistole 4 + die 3 = 14: the malus costs the success
+        assert_eq!(result.total, 14);
+        assert!(!result.outcome.is_success());
+    }
+
+    #[test]
+    fn test_check_attribute_auto_success() {
+        let character = unencumbered_shooter();
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let result =
+            character.check_attribute(Attribute::Body, 0, Difficulty::Custom(10), &mut roller);
+        assert_eq!(result.outcome, crate::dice::Outcome::AutoSuccess);
     }
 
     #[test]

--- a/src/character.rs
+++ b/src/character.rs
@@ -15,7 +15,8 @@ pub struct Character {
     pub age: i32,
     pub current_damage: i32,
     /// Available luck points. A persistent pool: spending survives the session,
-    /// [`Character::start_session`] regenerates half the base LUCK (rounded up).
+    /// [`Character::start_session`] regenerates half the current base LUCK
+    /// (rounded up). See [`Character::start_session`] for the three luck levels.
     pub current_luck: i32,
     pub damage_notes: String,
     pub worn_armor: Vec<Uuid>,
@@ -422,14 +423,43 @@ Character {{ \n\
         Ok(())
     }
 
-    /// Starts a new game session: regenerates half the base LUCK (rounded up),
-    /// capped at the LUCK attribute's current value.
+    /// Starts a new game session: regenerates luck points.
     ///
-    /// Example: base LUCK 9, 8 already spent (1 left) → +5 → starts with 6.
+    /// Luck has three levels:
+    /// - starting base (`AttributeValue.base`): the chargen value, never changes
+    /// - current base (`AttributeValue.actual`): permanently reducible via
+    ///   [`Character::sacrifice_luck`]; regeneration rate and cap come from here
+    /// - current pool (`Character.current_luck`): fluctuates with every roll
+    ///
+    /// Regenerates half the current base (rounded up), capped at the current
+    /// base. Example: current base 9, 8 already spent (1 left) → +5 → 6.
     pub fn start_session(&mut self) {
         let luck = self.attributes.get(&Attribute::Luck).unwrap();
-        let regenerated = (luck.base + 1) / 2;
+        let regenerated = (luck.actual + 1) / 2;
         self.current_luck = (self.current_luck + regenerated).min(luck.actual);
+    }
+
+    /// Permanently sacrifices luck for an extreme "the world now turns in your
+    /// favor" event: lowers the current base LUCK (`actual`), which also lowers
+    /// the regeneration rate and cap. The starting base is untouched. The
+    /// current pool is clamped to the new base if it now exceeds it.
+    pub fn sacrifice_luck(&mut self, points: i32) -> Result<(), String> {
+        if points < 0 {
+            return Err(format!(
+                "Cannot sacrifice a negative amount of luck: {}",
+                points
+            ));
+        }
+        let luck = self.attributes.get_mut(&Attribute::Luck).unwrap();
+        if points > luck.actual {
+            return Err(format!(
+                "Character '{}' has only {} base luck, tried to sacrifice {}",
+                self.name, luck.actual, points
+            ));
+        }
+        luck.actual -= points;
+        self.current_luck = self.current_luck.min(luck.actual);
+        Ok(())
     }
 
     /// Rolls a check on one of the character's skills.
@@ -937,9 +967,9 @@ mod tests {
     }
 
     #[test]
-    fn test_start_session_regenerates_half_base_luck() {
+    fn test_start_session_regenerates_half_current_base_luck() {
         let mut character = unencumbered_shooter();
-        // change base LUCK to 9 to mirror the example from the table rules
+        // current base LUCK 9 to mirror the example from the table rules
         character
             .attributes
             .insert(Attribute::Luck, AttributeValue::new(9, 9));
@@ -948,10 +978,45 @@ mod tests {
         // 1 + ceil(9/2) = 6
         assert_eq!(character.current_luck, 6);
 
-        // regeneration is capped at the LUCK attribute
+        // regeneration is capped at the current base
         character.current_luck = 8;
         character.start_session();
         assert_eq!(character.current_luck, 9);
+    }
+
+    #[test]
+    fn test_sacrifice_luck_lowers_current_base_and_regen() {
+        let mut character = unencumbered_shooter();
+        // starting base 9, still at full current base and pool
+        character
+            .attributes
+            .insert(Attribute::Luck, AttributeValue::new(9, 9));
+        character.current_luck = 9;
+
+        character.sacrifice_luck(4).unwrap();
+        let luck = character.attributes.get(&Attribute::Luck).unwrap();
+        // starting base untouched, current base lowered, pool clamped
+        assert_eq!(luck.base, 9);
+        assert_eq!(luck.actual, 5);
+        assert_eq!(character.current_luck, 5);
+
+        // regen now runs off the current base: 0 -> ceil(5/2) = 3, capped at 5
+        character.current_luck = 0;
+        character.start_session();
+        assert_eq!(character.current_luck, 3);
+        character.start_session();
+        character.start_session();
+        assert_eq!(character.current_luck, 5);
+    }
+
+    #[test]
+    fn test_sacrifice_luck_rejects_more_than_current_base() {
+        let mut character = unencumbered_shooter();
+        let error = character.sacrifice_luck(6).unwrap_err();
+        assert_eq!(
+            error,
+            "Character 'Shooter' has only 5 base luck, tried to sacrifice 6"
+        );
     }
 
     #[test]

--- a/src/dice.rs
+++ b/src/dice.rs
@@ -1,0 +1,358 @@
+/// Source of raw d10 rolls.
+///
+/// The rules engine never calls the RNG directly; it always goes through this
+/// trait so tests can script exact die sequences and a future server can
+/// record and replay rolls.
+pub trait DieRoller {
+    /// Rolls a single d10, returning a value in 1..=10.
+    fn d10(&mut self) -> i32;
+}
+
+/// The real thing: uniformly random d10s.
+pub struct RandomRoller;
+
+impl DieRoller for RandomRoller {
+    fn d10(&mut self) -> i32 {
+        rand::random_range(1..=10)
+    }
+}
+
+/// Scripted roller for tests and replays: returns the given values in order.
+///
+/// # Panics
+///
+/// Panics when more rolls are requested than values were provided, or when a
+/// value is outside 1..=10.
+pub struct SequenceRoller {
+    values: Vec<i32>,
+    next: usize,
+}
+
+impl SequenceRoller {
+    pub fn new(values: Vec<i32>) -> Self {
+        SequenceRoller { values, next: 0 }
+    }
+}
+
+impl DieRoller for SequenceRoller {
+    fn d10(&mut self) -> i32 {
+        let value = *self
+            .values
+            .get(self.next)
+            .expect("SequenceRoller ran out of scripted values");
+        assert!(
+            (1..=10).contains(&value),
+            "SequenceRoller value out of d10 range: {}",
+            value
+        );
+        self.next += 1;
+        value
+    }
+}
+
+/// Standard difficulties from the house rules: easy 10+, normal 15+, hard 20+.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Difficulty {
+    Easy,
+    Normal,
+    Hard,
+    Custom(i32),
+}
+
+impl Difficulty {
+    pub fn target(self) -> i32 {
+        match self {
+            Difficulty::Easy => 10,
+            Difficulty::Normal => 15,
+            Difficulty::Hard => 20,
+            Difficulty::Custom(target) => target,
+        }
+    }
+}
+
+/// How a skill check ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// Attribute + skill + committed luck already met the target: no roll,
+    /// always succeeds — even in combat.
+    AutoSuccess,
+    Success,
+    /// Failed by not reaching the target.
+    Failure,
+    /// Fumble (die showed 1), confirmation die 2-5: failed and looks silly.
+    EmbarrassingFailure,
+    /// Fumble (die showed 1), confirmation die 1: damage to yourself or your team.
+    CriticalFailure,
+}
+
+impl Outcome {
+    pub fn is_success(self) -> bool {
+        matches!(self, Outcome::AutoSuccess | Outcome::Success)
+    }
+}
+
+/// Full record of a skill check, kept for display and later replay.
+#[derive(Debug, PartialEq, Eq)]
+pub struct CheckResult {
+    pub outcome: Outcome,
+    /// attribute + skill + luck + die total (0 dice for an auto-success).
+    pub total: i32,
+    pub target: i32,
+    /// Natural die values in roll order, explosion re-rolls included.
+    pub die_rolls: Vec<i32>,
+    /// The severity die after a fumble, if one happened.
+    pub fumble_confirmation: Option<i32>,
+}
+
+/// Rolls a skill check against a difficulty, applying all dice house rules:
+///
+/// * **Auto-success**: if `attribute + skill + luck` already reaches the
+///   target, no die is rolled.
+/// * **Luck** modifies the first die directly (a rolled 9 plus 1 luck counts
+///   as a natural 10 and explodes; a rolled 1 plus luck is no fumble).
+///   Enforcing the per-evening luck budget is the caller's job.
+/// * **Exploding 10**: a (luck-adjusted) 10 adds and re-rolls until no 10
+///   comes up.
+/// * **Fumble**: a (luck-adjusted) 1 always fails; a confirmation die decides
+///   the severity: 1 critical, 2-5 embarrassing, 6-10 normal failure.
+pub fn skill_check(
+    attribute: i32,
+    skill: i32,
+    luck: i32,
+    difficulty: Difficulty,
+    roller: &mut dyn DieRoller,
+) -> CheckResult {
+    let target = difficulty.target();
+    let base = attribute + skill + luck;
+
+    if base >= target {
+        return CheckResult {
+            outcome: Outcome::AutoSuccess,
+            total: base,
+            target,
+            die_rolls: Vec::new(),
+            fumble_confirmation: None,
+        };
+    }
+
+    let first = roller.d10();
+    let mut die_rolls = vec![first];
+    let adjusted_first = first + luck;
+
+    if adjusted_first <= 1 {
+        let confirmation = roller.d10();
+        let outcome = match confirmation {
+            1 => Outcome::CriticalFailure,
+            2..=5 => Outcome::EmbarrassingFailure,
+            _ => Outcome::Failure,
+        };
+        return CheckResult {
+            outcome,
+            total: attribute + skill + adjusted_first,
+            target,
+            die_rolls,
+            fumble_confirmation: Some(confirmation),
+        };
+    }
+
+    let mut die_total = adjusted_first;
+    let mut last = adjusted_first;
+    while last >= 10 {
+        last = roller.d10();
+        die_rolls.push(last);
+        die_total += last;
+    }
+
+    let total = attribute + skill + die_total;
+    let outcome = if total >= target {
+        Outcome::Success
+    } else {
+        Outcome::Failure
+    };
+    CheckResult {
+        outcome,
+        total,
+        target,
+        die_rolls,
+        fumble_confirmation: None,
+    }
+}
+
+/// Record of an open-ended roll (no target): total speaks for itself.
+#[derive(Debug, PartialEq, Eq)]
+pub struct OpenRollResult {
+    /// attribute + skill + luck-adjusted die total.
+    pub total: i32,
+    /// Natural die values in roll order, explosion re-rolls included.
+    pub die_rolls: Vec<i32>,
+    /// True when the (luck-adjusted) die showed 1: an open roll can still fumble.
+    pub is_fumble: bool,
+    pub fumble_confirmation: Option<i32>,
+}
+
+/// Rolls openly (no difficulty): exploding 10s, luck and fumbles apply,
+/// interpretation of the total is up to the GM.
+pub fn open_roll(
+    attribute: i32,
+    skill: i32,
+    luck: i32,
+    roller: &mut dyn DieRoller,
+) -> OpenRollResult {
+    let first = roller.d10();
+    let mut die_rolls = vec![first];
+    let adjusted_first = first + luck;
+
+    if adjusted_first <= 1 {
+        let confirmation = roller.d10();
+        return OpenRollResult {
+            total: attribute + skill + adjusted_first,
+            die_rolls,
+            is_fumble: true,
+            fumble_confirmation: Some(confirmation),
+        };
+    }
+
+    let mut die_total = adjusted_first;
+    let mut last = adjusted_first;
+    while last >= 10 {
+        last = roller.d10();
+        die_rolls.push(last);
+        die_total += last;
+    }
+
+    OpenRollResult {
+        total: attribute + skill + die_total,
+        die_rolls,
+        is_fumble: false,
+        fumble_confirmation: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check(attr: i32, skill: i32, luck: i32, target: i32, rolls: Vec<i32>) -> CheckResult {
+        let mut roller = SequenceRoller::new(rolls);
+        skill_check(attr, skill, luck, Difficulty::Custom(target), &mut roller)
+    }
+
+    #[test]
+    fn test_auto_success_without_rolling() {
+        // 7 + 8 = 15 reaches Normal: no dice consumed, always succeeds.
+        let result = check(7, 8, 0, 15, vec![]);
+        assert_eq!(result.outcome, Outcome::AutoSuccess);
+        assert_eq!(result.total, 15);
+        assert!(result.die_rolls.is_empty());
+    }
+
+    #[test]
+    fn test_luck_counts_toward_auto_success() {
+        let result = check(7, 6, 2, 15, vec![]);
+        assert_eq!(result.outcome, Outcome::AutoSuccess);
+    }
+
+    #[test]
+    fn test_plain_success_and_failure() {
+        let success = check(5, 4, 0, 15, vec![7]);
+        assert_eq!(success.outcome, Outcome::Success);
+        assert_eq!(success.total, 16);
+
+        let failure = check(5, 4, 0, 15, vec![5]);
+        assert_eq!(failure.outcome, Outcome::Failure);
+        assert_eq!(failure.total, 14);
+    }
+
+    #[test]
+    fn test_exploding_tens_cascade() {
+        // 10 -> 10 -> 3 = die total 23.
+        let result = check(2, 0, 0, 20, vec![10, 10, 3]);
+        assert_eq!(result.outcome, Outcome::Success);
+        assert_eq!(result.total, 25);
+        assert_eq!(result.die_rolls, vec![10, 10, 3]);
+    }
+
+    #[test]
+    fn test_luck_turns_nine_into_exploding_ten() {
+        // Rolled 9 + 1 luck counts as a natural 10 and explodes (house rule).
+        let result = check(2, 2, 1, 20, vec![9, 6]);
+        assert_eq!(result.die_rolls, vec![9, 6]);
+        // 2 + 2 + (9 + 1) + 6 = 20
+        assert_eq!(result.total, 20);
+        assert_eq!(result.outcome, Outcome::Success);
+    }
+
+    #[test]
+    fn test_fumble_severities() {
+        let critical = check(5, 5, 0, 15, vec![1, 1]);
+        assert_eq!(critical.outcome, Outcome::CriticalFailure);
+        assert_eq!(critical.fumble_confirmation, Some(1));
+
+        let embarrassing = check(5, 5, 0, 15, vec![1, 4]);
+        assert_eq!(embarrassing.outcome, Outcome::EmbarrassingFailure);
+
+        let normal = check(5, 5, 0, 15, vec![1, 8]);
+        assert_eq!(normal.outcome, Outcome::Failure);
+        assert_eq!(normal.fumble_confirmation, Some(8));
+    }
+
+    #[test]
+    fn test_fumble_fails_even_when_total_would_succeed() {
+        // 7 + 7 + 1 = 15 would exactly reach the target,
+        // but a natural 1 is always a failure.
+        let result = check(7, 7, 0, 15, vec![1, 8]);
+        assert_eq!(result.outcome, Outcome::Failure);
+        assert_eq!(result.total, 15);
+    }
+
+    #[test]
+    fn test_luck_prevents_fumble() {
+        // Rolled 1 + 1 luck counts as 2: no fumble, evaluated normally.
+        let result = check(5, 5, 1, 15, vec![1]);
+        assert_eq!(result.outcome, Outcome::Failure);
+        assert_eq!(result.fumble_confirmation, None);
+        assert_eq!(result.total, 12);
+    }
+
+    #[test]
+    fn test_difficulty_targets() {
+        assert_eq!(Difficulty::Easy.target(), 10);
+        assert_eq!(Difficulty::Normal.target(), 15);
+        assert_eq!(Difficulty::Hard.target(), 20);
+        assert_eq!(Difficulty::Custom(35).target(), 35);
+    }
+
+    #[test]
+    fn test_open_roll_explodes_and_sums() {
+        let mut roller = SequenceRoller::new(vec![10, 4]);
+        let result = open_roll(6, 3, 0, &mut roller);
+        assert_eq!(result.total, 23);
+        assert_eq!(result.die_rolls, vec![10, 4]);
+        assert!(!result.is_fumble);
+    }
+
+    #[test]
+    fn test_open_roll_fumbles() {
+        let mut roller = SequenceRoller::new(vec![1, 3]);
+        let result = open_roll(6, 3, 0, &mut roller);
+        assert!(result.is_fumble);
+        assert_eq!(result.fumble_confirmation, Some(3));
+    }
+
+    #[test]
+    fn test_random_roller_stays_in_range() {
+        let mut roller = RandomRoller;
+        for _ in 0..1000 {
+            let roll = roller.d10();
+            assert!((1..=10).contains(&roll), "d10 out of range: {}", roll);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "ran out of scripted values")]
+    fn test_sequence_roller_exhaustion_panics() {
+        let mut roller = SequenceRoller::new(vec![5]);
+        roller.d10();
+        roller.d10();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,14 @@
 mod armor;
 mod character;
+mod dice;
 mod inventory;
 mod weapons;
 
 pub use self::armor::{Armor, HitZone};
 pub use self::character::{Attribute, AttributeValue, Character, List, Skill};
+pub use self::dice::{open_roll, skill_check};
+pub use self::dice::{
+    CheckResult, DieRoller, Difficulty, OpenRollResult, Outcome, RandomRoller, SequenceRoller,
+};
 pub use self::inventory::{Inventory, Item};
 pub use self::weapons::DamageType;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,44 @@
-use rusted_punk::{Armor, Attribute, Character, DamageType, HitZone, Item, List, Skill};
+use rusted_punk::{
+    Armor, Attribute, Character, DamageType, Difficulty, HitZone, Item, List, RandomRoller, Skill,
+};
 
 fn main() {
     armor_test();
     character_test();
     skill_test();
     list_test();
+    dice_test();
+}
+
+fn dice_test() {
+    let mut character = Character::new(
+        "Testschütze".to_string(),
+        "Solo".to_string(),
+        25,
+        5,
+        6,
+        5,
+        5,
+        5,
+        5,
+        7,
+        8,
+        5,
+    );
+    character
+        .skills
+        .push(Skill::new("Pistole".to_string(), Attribute::Reflexes, 4, 1));
+
+    let mut roller = RandomRoller;
+    for difficulty in [Difficulty::Easy, Difficulty::Normal, Difficulty::Hard] {
+        let result = character
+            .check_skill("Pistole", 0, difficulty, &mut roller)
+            .unwrap();
+        println!(
+            "Pistole vs {:?} ({}): {:?} — total {} (dice {:?})",
+            difficulty, result.target, result.outcome, result.total, result.die_rolls
+        );
+    }
 }
 
 fn armor_test() {

--- a/tools/fandom.py
+++ b/tools/fandom.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Small helper for reading and writing pages on desaster.fandom.com.
+
+Credentials: ~/.config/rustedpunk-agent/fandom.password with two lines,
+`User: <name@botname>` and `Password: <bot password>` (Fandom bot password,
+created via Spezial:BotPasswords). The file is never committed.
+
+Usage:
+    tools/fandom.py get <PageName>            # prints wikitext to stdout
+    tools/fandom.py put <PageName> <file> "<edit summary>"
+"""
+import http.cookiejar
+import json
+import pathlib
+import sys
+import urllib.parse
+import urllib.request
+
+API = "https://desaster.fandom.com/api.php"
+UA = "rustedPunk-agent/0.1 (Ben's campaign tool; contact ben@sommerfuchs.info)"
+
+_opener = urllib.request.build_opener(
+    urllib.request.HTTPCookieProcessor(http.cookiejar.CookieJar())
+)
+
+
+def _call(params, post=False):
+    params = dict(params, format="json")
+    data = urllib.parse.urlencode(params).encode()
+    if post:
+        req = urllib.request.Request(API, data=data, headers={"User-Agent": UA})
+    else:
+        req = urllib.request.Request(API + "?" + data.decode(), headers={"User-Agent": UA})
+    with _opener.open(req, timeout=30) as response:
+        return json.load(response)
+
+
+def _credentials():
+    creds = {}
+    path = pathlib.Path.home() / ".config/rustedpunk-agent/fandom.password"
+    for line in path.read_text().splitlines():
+        if ":" in line:
+            key, value = line.split(":", 1)
+            creds[key.strip().lower()] = value.strip()
+    return creds
+
+
+def login():
+    creds = _credentials()
+    token = _call({"action": "query", "meta": "tokens", "type": "login"})["query"]["tokens"]["logintoken"]
+    result = _call(
+        {"action": "login", "lgname": creds["user"], "lgpassword": creds["password"], "lgtoken": token},
+        post=True,
+    )
+    if result["login"]["result"] != "Success":
+        raise SystemExit(f"Fandom login failed: {result['login']['result']}")
+    return _call({"action": "query", "meta": "tokens"})["query"]["tokens"]["csrftoken"]
+
+
+def get_page(page):
+    return _call({"action": "parse", "page": page, "prop": "wikitext"})["parse"]["wikitext"]["*"]
+
+
+def put_page(csrf, page, text, summary):
+    result = _call(
+        {"action": "edit", "title": page, "text": text, "summary": summary, "token": csrf, "nocreate": 1},
+        post=True,
+    )
+    status = result.get("edit", {}).get("result")
+    if status != "Success":
+        raise SystemExit(f"Edit of '{page}' failed: {result}")
+    print(f"{page}: {status}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 3 and sys.argv[1] == "get":
+        print(get_page(sys.argv[2]))
+    elif len(sys.argv) >= 5 and sys.argv[1] == "put":
+        csrf = login()
+        put_page(csrf, sys.argv[2], pathlib.Path(sys.argv[3]).read_text(), sys.argv[4])
+    else:
+        raise SystemExit(__doc__)


### PR DESCRIPTION
Implements milestone M1 / issue #11 per the house rules in PROJECT-STRUCTURE.md §3:

**Core (`dice.rs`)**
- `skill_check(attribute, skill, luck, difficulty, roller)`: auto-success when attribute+skill+luck ≥ target (no roll — even in combat), exploding 10s (cascade), fumble on natural 1 with confirmation die (1 = critical, 2–5 = embarrassing, 6–10 = normal failure), luck modifies the first die directly (a 9 + 1 luck is a natural 10 and explodes; symmetrically, 1 + 1 luck is no fumble — confirmed by Ben, Q16)
- `open_roll(...)`: same mechanics, no target — for GM-interpreted rolls
- `DieRoller` trait with `RandomRoller` (rand 0.10) and `SequenceRoller` (scripted; used by all tests, later usable for roll replay on the server)
- `Difficulty::{Easy 10, Normal 15, Hard 20, Custom(n)}`

**Character integration**
- `Character::check_skill("Pistole", luck, difficulty, roller)` — resolves the skill by name, uses `effective_attribute()` so encumbrance maluses flow into rolls automatically; returns a meaningful error for unknown skills
- `Character::check_attribute(...)` for untrained checks

**Luck, three levels (per Ben's rulings 2026-07-09)**
- *Starting base* (`AttributeValue.base`): chargen value, never changes
- *Current base* (`AttributeValue.actual`): permanently reducible via `Character::sacrifice_luck()` for extreme "the world now turns in your favor" events — regeneration rate and cap derive from it
- *Current pool* (`Character.current_luck`): persistent across sessions; committed luck is deducted by the check methods (also on auto-success), overspending errors without rolling anything
- `Character::start_session()` regenerates ceil(current base / 2), capped at the current base — current base 9 with 1 left → starts next session at 6

22 new tests (48 total, all passing). `main.rs` got a small dice demo.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)