### PR TITLE
feat: Prellschaden, penetration cap, wound states (M2, #19/#13)

### DIFF
--- a/AI-README.md
+++ b/AI-README.md
@@ -85,23 +85,36 @@ Each damage type has a private helper method. Full mechanics documented on publi
 
 ---
 
-## Character Damage Mechanics (`character.rs`)
+## Character Damage Mechanics (`character.rs`, `health.rs`)
 
-### `Character.hit(damage, zone, damage_type)` - IMPLEMENTED
+### `Character.hit(damage, zone, damage_type, is_gunshot, roller)` → `HitOutcome`
 - Processes damage through all worn armor layers (outside-in, reverse iteration)
-- Each layer's `Armor.hit()` returns remaining damage to pass to next layer
-- Applies 20% blunt trauma house rule: `absorbed_damage / 5` added back as damage
-- Calls `take_damage()` with final remaining damage after all armor
+- Damage absorbed by SOFT armor becomes Prellschaden point-for-point; hard
+  armor absorbs without consequence (Q20)
+- **Penetration cap** (gunshots only): more than 4 remaining damage rolls 1d10;
+  the shot does at most `4 + 1d10` — the rest exits through the back
+  (`through_and_through` in the outcome)
+- Then delegates to `resolve_damage` (same core as `take_damage`)
+- TODO(Q17): hollow-point double damage vs soft targets pending ruling
 
-### `Character.take_damage(damage, zone)` - IMPLEMENTED
-- Bypasses armor, applies damage directly to character
-- Applies Body Type Modifier (BTM) with minimum 1 damage rule (CP2020 RAW),
-  implemented as `(damage - btm).max(1)`
-- **Head damage doubles** after BTM calculation
-- **Crippling damage** (8+ points after BTM):
-  - **Critical zones (Head/Chest/Vitals)**: Instant death, sets `current_damage = 100`
-  - **Other zones**: Mortal 0 state, minimum `current_damage = 13` (doesn't reduce if already higher)
-- Updates `damage_notes` with death/crippling messages
+### `Character.take_damage(damage, zone)` → `HitOutcome`
+- Bypasses armor. BTM is SUBTRACTED and CONVERTED to Prellschaden (min 1 real
+  damage remains): `converted = btm.min(damage - 1)`
+- **Prellschaden scale** (`current_bruise`, 0–4): every 5 points → 1 real
+  damage + KO check required (`ko_check_required`); a hit causing ONLY
+  Prellschaden instead sets `pending_roll_malus` (consumed by the next
+  check_skill/check_attribute)
+- **Crippling check** (8+ zone damage after BTM) uses the UNDOUBLED value;
+  **head doubling** applies afterwards:
+  - Critical zones (Head/Chest/Vitals): instant death, `current_damage = 100`
+  - Other zones: Mortal 0 state, minimum `current_damage = 13`
+
+### Wound states (`health.rs::WoundState`)
+- Blocks of 4 damage: Light (1-4, no malus), Serious (5-8, −2 REF), Critical
+  (9-12, REF/INT/COOL halved round up), Mortal 0-4 (13-32, all stats except
+  LUCK/EMP divided by 3 round up), Dead (>32)
+- `Character::wound_state()`; penalties are applied inside
+  `effective_attribute()` BEFORE encumbrance is subtracted (Q19)
 
 ---
 

--- a/AI-README.md
+++ b/AI-README.md
@@ -95,7 +95,15 @@ Each damage type has a private helper method. Full mechanics documented on publi
   the shot does at most `4 + 1d10` — the rest exits through the back
   (`through_and_through` in the outcome)
 - Then delegates to `resolve_damage` (same core as `take_damage`)
-- TODO(Q17): hollow-point double damage vs soft targets pending ruling
+- **HollowPoint** (Q17): mushrooms — halved vs hard armor (in `Armor.hit`),
+  full damage vs soft armor; damage reaching flesh DOUBLES and the projectile
+  never exits (no penetration cap)
+
+### Healing (Q18)
+- `Character::rest_day(healer_present)`: heals 1/day with healer, 1 per two
+  days without (`healing_progress` carries the half-day)
+- `Character::complication_check(healer_present, roller)`: morning-after BODY
+  roll vs 10 + current damage; `None` with a healer (no check needed)
 
 ### `Character.take_damage(damage, zone)` → `HitOutcome`
 - Bypasses armor. BTM is SUBTRACTED and CONVERTED to Prellschaden (min 1 real

--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -4,5 +4,26 @@ Standing Q&A file: Claude collects questions here so Ben can answer them in one
 go; answered questions are folded into PROJECT-STRUCTURE.md (marked *(decided)*)
 and removed.
 
-**No open questions right now.** (Q1–Q16 answered; decisions live in
-PROJECT-STRUCTURE.md, section 3.)
+**Q17 — Dum-dum "doppelt gegen weiche Ziele" (issue #19).** The wiki says
+hollow-point works at half effect against hard armor and double against soft
+targets. What exactly doubles: the damage that penetrates to the character
+when the zone has no/only soft armor? Or all penetrating damage? (Currently
+armor-level behavior only: incoming halved before armor. TODO(Q17) in
+`character.rs::hit`.)
+
+**Q18 — Base healing rate (issue #13).** The wiki only defines the modifiers:
+"Schnelle Heilung" heals at double rate, "Langsame Heilung" rolls only every
+two days whether healing happens. What is the base rule at your table — a
+daily roll (against what?), or fixed points per day like CP2020 RAW? And how
+do the crippling-chance rolls (5% / 0.5% with care) time-wise fit in — once
+per injury?
+
+**Q19 — Order of maluses (implemented, confirm).** For effective attributes I
+apply wound penalties first (halving/thirding the sheet value), then subtract
+encumbrance, floor at 0. E.g. REF 8, Critical (→4), encumbrance −2 → 2. OK?
+
+**Q20 — Prellschaden amount per hit (implemented, confirm).** Soft-armor
+absorbed damage goes onto the bruise scale point-for-point (18 absorbed = 18
+Prellschaden = 3 real damage + scale at 3). Evidence: your old 20%
+approximation was exactly absorbed/5. Same point-for-point reading for the
+BTM conversion. OK?

--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -4,26 +4,5 @@ Standing Q&A file: Claude collects questions here so Ben can answer them in one
 go; answered questions are folded into PROJECT-STRUCTURE.md (marked *(decided)*)
 and removed.
 
-**Q17 — Dum-dum "doppelt gegen weiche Ziele" (issue #19).** The wiki says
-hollow-point works at half effect against hard armor and double against soft
-targets. What exactly doubles: the damage that penetrates to the character
-when the zone has no/only soft armor? Or all penetrating damage? (Currently
-armor-level behavior only: incoming halved before armor. TODO(Q17) in
-`character.rs::hit`.)
-
-**Q18 — Base healing rate (issue #13).** The wiki only defines the modifiers:
-"Schnelle Heilung" heals at double rate, "Langsame Heilung" rolls only every
-two days whether healing happens. What is the base rule at your table — a
-daily roll (against what?), or fixed points per day like CP2020 RAW? And how
-do the crippling-chance rolls (5% / 0.5% with care) time-wise fit in — once
-per injury?
-
-**Q19 — Order of maluses (implemented, confirm).** For effective attributes I
-apply wound penalties first (halving/thirding the sheet value), then subtract
-encumbrance, floor at 0. E.g. REF 8, Critical (→4), encumbrance −2 → 2. OK?
-
-**Q20 — Prellschaden amount per hit (implemented, confirm).** Soft-armor
-absorbed damage goes onto the bruise scale point-for-point (18 absorbed = 18
-Prellschaden = 3 real damage + scale at 3). Evidence: your old 20%
-approximation was exactly absorbed/5. Same point-for-point reading for the
-BTM conversion. OK?
+**No open questions right now.** (Q1–Q20 answered; decisions live in
+PROJECT-STRUCTURE.md, section 3.)

--- a/PROJECT-STRUCTURE.md
+++ b/PROJECT-STRUCTURE.md
@@ -152,8 +152,14 @@ Design rules already established (keep them):
   (TODO `character.rs:282`: cap at 4 + 1d10).
 - **Crippling injuries**: critical-or-worse wounds have 5% crippling chance without
   proper medical care (0.5% with care).
-- Ammo types: AP (armor halved, damage vs soft targets halved), dum-dum/HP (half
-  vs hard armor, double vs soft targets — TODO `character.rs:281`).
+- Ammo types: AP (armor halved, damage vs soft targets halved); dum-dum/HP
+  *(decided, Q17)*: mushrooms — vs hard armor the damage counts half; soft
+  armor faces the full damage (generating Prellschaden as usual); damage that
+  reaches flesh is DOUBLED and the projectile never exits (no penetration cap).
+- **Healing** *(decided, Q18)*: the morning after a wound, BODY roll vs
+  10 + taken damage or complications arise — skipped entirely when a healer is
+  present (practically always). Healing rate: 1 damage per two days, with a
+  healer 1 per day.
 - Fire damage ignores the ">8 damage" rule.
 
 ### Encumbrance (`character.rs`, `inventory.rs`) — implemented, #12 ✓
@@ -259,10 +265,11 @@ The workshop trade system IS in scope.)*
 - **M1 — Dice engine (#11)**: pure, seedable RNG (inject `rand::Rng` or a trait for
   testability), skill checks, exploding/fumble/luck/auto-success. Everything later
   (combat, chargen, NSCs) consumes this.
-- **M2 — Damage details (#19) + injuries & healing (#13)**: *damage side done
-  2026-07-09* (Prellschaden scale, BTM conversion, penetration cap, head-hit
-  ordering, health blocks, wound penalties). Still open: hollow-point vs soft
-  targets (Q17), healing over time + KO check (Q18), crippling-chance rolls.
+- **M2 — Damage details (#19) + injuries & healing (#13)**: *done 2026-07-09*
+  (Prellschaden scale, BTM conversion, penetration cap, head-hit ordering,
+  health blocks, wound penalties, hollow-point flesh doubling, healing rates,
+  complication check). Deferred: KO-check resolution mechanics and the 5%
+  crippling roll (need the advantage system for the modifiers anyway, → M3).
 - **M3 — Dis-/advantages (#10)**: storage first, then a generic `Modifier`
   mechanism (source, target attr/skill/roll-tag, value) that encumbrance and wound
   penalties can migrate onto.

--- a/PROJECT-STRUCTURE.md
+++ b/PROJECT-STRUCTURE.md
@@ -259,10 +259,10 @@ The workshop trade system IS in scope.)*
 - **M1 — Dice engine (#11)**: pure, seedable RNG (inject `rand::Rng` or a trait for
   testability), skill checks, exploding/fumble/luck/auto-success. Everything later
   (combat, chargen, NSCs) consumes this.
-- **M2 — Damage details (#19) + injuries & healing (#13)**: replace the 20%
-  blunt-trauma approximation with the Prellschaden scale, BTM→Prellschaden
-  conversion, the remaining `Character::hit()` TODOs, health blocks, wound
-  penalties into `effective_attribute()`, healing over time.
+- **M2 — Damage details (#19) + injuries & healing (#13)**: *damage side done
+  2026-07-09* (Prellschaden scale, BTM conversion, penetration cap, head-hit
+  ordering, health blocks, wound penalties). Still open: hollow-point vs soft
+  targets (Q17), healing over time + KO check (Q18), crippling-chance rolls.
 - **M3 — Dis-/advantages (#10)**: storage first, then a generic `Modifier`
   mechanism (source, target attr/skill/roll-tag, value) that encumbrance and wound
   penalties can migrate onto.

--- a/docs/rules/Regeln.wiki
+++ b/docs/rules/Regeln.wiki
@@ -67,6 +67,11 @@ Im dritten Block (kritische Wunden): REF, INT, COOL halbiert (aufrunden)
 
 Ab dem vierten Block (tödlich): Alle Stats außer LUCK, EMP dritteln (aufrunden)
 
+=== Heilung ===
+Am Morgen nach einer Verwundung: BODY-Wurf gegen 10 + erlittenen Schaden, sonst gibt es Komplikationen. Ist ein Heiler anwesend (praktisch immer), entfällt der Wurf.
+
+Geheilt wird ein Punkt alle zwei Tage; mit Heiler ein Punkt pro Tag.
+
 ===Spezial===
 
 ==== Durchschlag bei Schusswaffen ====
@@ -99,7 +104,7 @@ Der Schaden ein Schusswaffe ist abhängig von ihrem Kaliber und beim Waffentyp m
 Panzerbrechende Munition ist besonders hart und spitz. Rüstung zielt nur halb gegen diese Munition, jedoch wird der Schaden gegen weiche Ziele halbiert, da die Kugel einfach durchschlägt.
 
 ====Dum Dum====
-Der Kontrast zu Panzerbrechender Munition, wirkt nur halb gegen harte Rüstung, dafür doppelt gegen weiche Ziele.
+Dum-Dum-Geschosse pilzen auf. Gegen harte Rüstung zählt der Schaden nur halb (das aufgepilzte Geschoss verliert Durchschlagskraft). Weiche Rüstung fängt den vollen Schaden (und erzeugt entsprechend Prellschaden). Schaden der ins Fleisch durchdringt wird verdoppelt — und das Geschoss verlässt den Körper nicht (kein Durchschuss).
 
 ====Autofeuer====
 Wenn man einigermaßen nah an einem Gegner dran ist kann man die Waffe auf automatisch stellen und das Magazin in die Richtung seines Gegners beschleunigen.

--- a/src/armor.rs
+++ b/src/armor.rs
@@ -139,7 +139,9 @@ impl Armor {
     ///
     /// * `ArmorPiercing` - Halves effective protection, halves remaining damage that penetrates
     /// * `Blunt` - Uses full protection value, no damage modifications
-    /// * `HollowPoint` - Halves incoming damage before armor calculation
+    /// * `HollowPoint` - Mushrooms against HARD armor: incoming damage halved.
+    ///   Soft armor faces the full damage. (Damage that reaches flesh doubles —
+    ///   handled in `Character::hit`.)
     /// * `Slashing` - Hard armor protects fully. Soft armor protects half. Damage isn't halved like armor piercing.
     ///
     /// When armor protection is insufficient to stop the attack, the armor's durability
@@ -220,7 +222,11 @@ impl Armor {
     /// This function also reduces the armor's durability by 1, IF the armor has been penetrated.
     fn hit_hollow_point(&mut self, zone: HitZone, remaining_damage: &mut i32) -> i32 {
         let protection = self.protection_current[&zone];
-        *remaining_damage = (*remaining_damage + 1) / 2;
+        // The projectile mushrooms out against a hard surface and loses
+        // penetrating power. Soft armor faces the full damage.
+        if self.is_hard {
+            *remaining_damage = (*remaining_damage + 1) / 2;
+        }
         let absorbed_damage;
 
         if protection >= *remaining_damage {
@@ -400,7 +406,7 @@ pub mod tests {
         test_armor_hit(&mut flak_vest(), 10, DamageType::Blunt, 0, 10, 20);
         test_armor_hit(&mut kev_shirt(), 10, DamageType::Blunt, 0, 10, 10);
         test_armor_hit(&mut flak_vest(), 10, DamageType::HollowPoint, 0, 5, 20);
-        test_armor_hit(&mut kev_shirt(), 10, DamageType::HollowPoint, 0, 5, 10);
+        test_armor_hit(&mut kev_shirt(), 10, DamageType::HollowPoint, 0, 10, 10);
         test_armor_hit(&mut flak_vest(), 10, DamageType::Slashing, 0, 10, 20);
         test_armor_hit(&mut kev_shirt(), 10, DamageType::Slashing, 5, 5, 9);
 
@@ -409,7 +415,7 @@ pub mod tests {
         test_armor_hit(&mut flak_vest(), 7, DamageType::Blunt, 0, 7, 20);
         test_armor_hit(&mut kev_shirt(), 7, DamageType::Blunt, 0, 7, 10);
         test_armor_hit(&mut flak_vest(), 7, DamageType::HollowPoint, 0, 4, 20);
-        test_armor_hit(&mut kev_shirt(), 7, DamageType::HollowPoint, 0, 4, 10);
+        test_armor_hit(&mut kev_shirt(), 7, DamageType::HollowPoint, 0, 7, 10);
         test_armor_hit(&mut flak_vest(), 7, DamageType::Slashing, 0, 7, 20);
         test_armor_hit(&mut kev_shirt(), 7, DamageType::Slashing, 2, 5, 9);
 
@@ -419,7 +425,7 @@ pub mod tests {
         test_armor_hit(&mut kev_shirt(), 29, DamageType::Blunt, 19, 10, 9);
         test_armor_hit(&mut flak_vest(), 29, DamageType::HollowPoint, 0, 15, 20);
         test_armor_hit(&mut flak_vest(), 49, DamageType::HollowPoint, 5, 20, 19);
-        test_armor_hit(&mut kev_shirt(), 29, DamageType::HollowPoint, 5, 10, 9);
+        test_armor_hit(&mut kev_shirt(), 29, DamageType::HollowPoint, 19, 10, 9);
         test_armor_hit(&mut flak_vest(), 29, DamageType::Slashing, 9, 20, 19);
         test_armor_hit(&mut kev_shirt(), 29, DamageType::Slashing, 24, 5, 9);
 
@@ -428,7 +434,7 @@ pub mod tests {
         test_armor_hit(&mut flak_vest(), 12, DamageType::Blunt, 0, 12, 20);
         test_armor_hit(&mut kev_shirt(), 12, DamageType::Blunt, 2, 10, 9);
         test_armor_hit(&mut flak_vest(), 12, DamageType::HollowPoint, 0, 6, 20);
-        test_armor_hit(&mut kev_shirt(), 12, DamageType::HollowPoint, 0, 6, 10);
+        test_armor_hit(&mut kev_shirt(), 12, DamageType::HollowPoint, 2, 10, 9);
         test_armor_hit(&mut flak_vest(), 12, DamageType::Slashing, 0, 12, 20);
         test_armor_hit(&mut kev_shirt(), 12, DamageType::Slashing, 7, 5, 9);
 
@@ -437,7 +443,7 @@ pub mod tests {
         test_armor_hit(&mut flak_vest(), 13, DamageType::Blunt, 0, 13, 20);
         test_armor_hit(&mut kev_shirt(), 13, DamageType::Blunt, 3, 10, 9);
         test_armor_hit(&mut flak_vest(), 13, DamageType::HollowPoint, 0, 7, 20);
-        test_armor_hit(&mut kev_shirt(), 13, DamageType::HollowPoint, 0, 7, 10);
+        test_armor_hit(&mut kev_shirt(), 13, DamageType::HollowPoint, 3, 10, 9);
         test_armor_hit(&mut flak_vest(), 13, DamageType::Slashing, 0, 13, 20);
         test_armor_hit(&mut kev_shirt(), 13, DamageType::Slashing, 8, 5, 9);
 

--- a/src/character.rs
+++ b/src/character.rs
@@ -21,6 +21,9 @@ pub struct Character {
     /// Malus from pure bruise damage, applied to (and consumed by) the
     /// character's next check.
     pub pending_roll_malus: i32,
+    /// Healing progress in half-points: a healer day counts 2, a day without
+    /// counts 1; every 2 half-points heal 1 damage (see [`Character::rest_day`]).
+    pub healing_progress: i32,
     /// Available luck points. A persistent pool: spending survives the session,
     /// [`Character::start_session`] regenerates half the current base LUCK
     /// (rounded up). See [`Character::start_session`] for the three luck levels.
@@ -176,6 +179,7 @@ impl Character {
             current_damage: 0,
             current_bruise: 0,
             pending_roll_malus: 0,
+            healing_progress: 0,
             current_luck: luck,
             damage_notes: "".to_string(),
             skills: Vec::new(),
@@ -280,6 +284,42 @@ Character {{ \n\
         WoundState::from_damage(self.current_damage)
     }
 
+    /// A day of rest: heals 1 damage per day with a healer present,
+    /// 1 per two days without (progress carries over between days).
+    pub fn rest_day(&mut self, healer_present: bool) {
+        if self.current_damage == 0 || self.wound_state() == WoundState::Dead {
+            return;
+        }
+        self.healing_progress += if healer_present { 2 } else { 1 };
+        self.current_damage = (self.current_damage - self.healing_progress / 2).max(0);
+        self.healing_progress %= 2;
+        if self.current_damage == 0 {
+            self.healing_progress = 0;
+        }
+    }
+
+    /// The morning-after complication check: BODY against 10 + current damage.
+    /// With a healer present (practically always) no check is needed and
+    /// `None` is returned. A failed check means complications — interpreting
+    /// them is up to the GM.
+    pub fn complication_check(
+        &mut self,
+        healer_present: bool,
+        roller: &mut dyn DieRoller,
+    ) -> Option<CheckResult> {
+        if healer_present {
+            return None;
+        }
+        let difficulty = Difficulty::Custom(10 + self.current_damage);
+        Some(skill_check(
+            self.effective_attribute(Attribute::Body),
+            0,
+            0,
+            difficulty,
+            roller,
+        ))
+    }
+
     /// Returns the effective attribute value for dice rolls, including all
     /// temporary modifiers (wound penalties, encumbrance, etc.).
     ///
@@ -381,10 +421,14 @@ Character {{ \n\
             }
         }
 
-        // House rule: a gunshot doing more than 4 damage rolls 1d10 — that is
-        // the maximum extra damage before the shot exits through the back.
         let mut through_and_through = false;
-        if is_gunshot && remaining_damage > 4 {
+        if damage_type == DamageType::HollowPoint {
+            // Q17: the mushroomed projectile doubles its damage as soon as it
+            // enters flesh — and doesn't exit the body, so no penetration cap.
+            remaining_damage *= 2;
+        } else if is_gunshot && remaining_damage > 4 {
+            // House rule: a gunshot doing more than 4 damage rolls 1d10 — that
+            // is the maximum extra damage before the shot exits through the back.
             let cap = 4 + roller.d10();
             if remaining_damage > cap {
                 remaining_damage = cap;
@@ -392,8 +436,6 @@ Character {{ \n\
             }
         }
 
-        // TODO(Q17): HollowPoint/dum-dum double damage against soft targets —
-        // pending ruling on what exactly counts as a soft target.
         let mut outcome = self.resolve_damage(remaining_damage, soft_absorbed, zone);
         outcome.through_and_through = through_and_through;
         outcome
@@ -954,6 +996,77 @@ mod tests {
             character.wound_state(),
             crate::health::WoundState::Mortal(0)
         );
+    }
+
+    #[test]
+    fn test_hollow_point_doubles_in_flesh_and_never_exits() {
+        // Ben's Q17 example: 8 damage against 4-SP soft armor. The armor
+        // consumes 4 (-> Prellschaden); the remaining 4 double in the flesh,
+        // so 8 (minus BTM) reach the character. No through-and-through.
+        let mut character = unencumbered_shooter(); // BODY 10, BTM 4
+        let cloak = long_leather_cloak(); // soft, 4 SP, covers Chest
+        let cloak_uuid = cloak.item.uuid;
+        character.inventory.push(Box::new(cloak));
+        character.wear_armor(cloak_uuid, None);
+
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let outcome = character.hit(
+            8,
+            HitZone::Chest,
+            DamageType::HollowPoint,
+            true,
+            &mut roller,
+        );
+
+        assert!(!outcome.through_and_through, "hollow point never exits");
+        // doubled to 8, BTM converts 4 -> 4 real; bruise = 4 (armor) + 4 (BTM)
+        // = 8 -> 1 converted damage, scale at 3
+        assert_eq!(character.current_damage, 4 + 1);
+        assert_eq!(character.current_bruise, 3);
+        assert!(outcome.ko_check_required);
+    }
+
+    #[test]
+    fn test_rest_day_healing_rates() {
+        let mut character = unencumbered_shooter();
+        character.current_damage = 6;
+
+        // without a healer: 1 point per two days
+        character.rest_day(false);
+        assert_eq!(character.current_damage, 6);
+        character.rest_day(false);
+        assert_eq!(character.current_damage, 5);
+
+        // with a healer: 1 point per day (carried half-progress stays intact)
+        character.rest_day(true);
+        assert_eq!(character.current_damage, 4);
+
+        // healing stops at 0 and never goes negative
+        character.current_damage = 1;
+        character.rest_day(true);
+        character.rest_day(true);
+        assert_eq!(character.current_damage, 0);
+    }
+
+    #[test]
+    fn test_complication_check_only_without_healer() {
+        let mut character = unencumbered_shooter(); // BODY 10
+        character.current_damage = 4;
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        assert!(character.complication_check(true, &mut roller).is_none());
+
+        // without healer: BODY vs 10 + damage = 14. BODY 10 + die 5 = 15: passed.
+        let mut roller = crate::dice::SequenceRoller::new(vec![5]);
+        let result = character.complication_check(false, &mut roller).unwrap();
+        assert_eq!(result.target, 14);
+        assert!(result.outcome.is_success());
+
+        // heavily wounded: wound penalties make BODY worse (Mortal thirds it)
+        character.current_damage = 14;
+        let mut roller = crate::dice::SequenceRoller::new(vec![5]);
+        let result = character.complication_check(false, &mut roller).unwrap();
+        // effective BODY 4 + die 5 = 9 vs 24: failed
+        assert!(!result.outcome.is_success());
     }
 
     #[test]

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,4 +1,5 @@
 use crate::dice::{skill_check, CheckResult, DieRoller, Difficulty};
+use crate::health::WoundState;
 use crate::{armor::HitZone, Armor};
 use crate::{inventory::Inventory, DamageType};
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,12 @@ pub struct Character {
     pub role: String,
     pub age: i32,
     pub current_damage: i32,
+    /// Prellschaden scale: accumulated bruise points (0–4). Every 5 points
+    /// convert into 1 real damage and the scale resets.
+    pub current_bruise: i32,
+    /// Malus from pure bruise damage, applied to (and consumed by) the
+    /// character's next check.
+    pub pending_roll_malus: i32,
     /// Available luck points. A persistent pool: spending survives the session,
     /// [`Character::start_session`] regenerates half the current base LUCK
     /// (rounded up). See [`Character::start_session`] for the three luck levels.
@@ -126,6 +133,24 @@ impl fmt::Display for AttributeValue {
     }
 }
 
+/// Report of what a hit (or direct damage) did to the character.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct HitOutcome {
+    /// Real damage added to `current_damage` (head doubling and converted
+    /// bruise damage included).
+    pub real_damage: i32,
+    /// Prellschaden points this hit put on the bruise scale
+    /// (soft-armor absorption + BTM conversion).
+    pub bruise_added: i32,
+    /// Real damage that came from the bruise scale filling up
+    /// (already part of `real_damage`).
+    pub converted_bruise_damage: i32,
+    /// The bruise scale converted to real damage: a KO check is required.
+    pub ko_check_required: bool,
+    /// The penetration cap kicked in: the shot exited through the back.
+    pub through_and_through: bool,
+}
+
 impl Character {
     pub fn new(
         name: String,
@@ -149,6 +174,8 @@ impl Character {
             inventory: Inventory::new(),
             worn_armor: Vec::new(),
             current_damage: 0,
+            current_bruise: 0,
+            pending_roll_malus: 0,
             current_luck: luck,
             damage_notes: "".to_string(),
             skills: Vec::new(),
@@ -248,18 +275,29 @@ Character {{ \n\
         }
     }
 
+    /// The character's wound state, derived from the current damage.
+    pub fn wound_state(&self) -> WoundState {
+        WoundState::from_damage(self.current_damage)
+    }
+
     /// Returns the effective attribute value for dice rolls, including all
-    /// temporary modifiers (encumbrance, drugs, combat effects, etc.).
+    /// temporary modifiers (wound penalties, encumbrance, etc.).
+    ///
+    /// Order: wound penalties modify the attribute first, encumbrance maluses
+    /// are subtracted afterwards, the result never drops below 0 (see Q19).
     pub fn effective_attribute(&self, attr: Attribute) -> i32 {
-        let base_value = self.attributes[&attr].actual;
+        let mut value = self
+            .wound_state()
+            .modify_attribute(attr, self.attributes[&attr].actual);
 
         match attr {
             Attribute::Reflexes => {
-                (base_value - self.encumberance() - self.calculate_armor_encumberance()).max(0)
+                value -= self.encumberance() + self.calculate_armor_encumberance()
             }
-            Attribute::Move => (base_value - self.encumberance()).max(0),
-            _ => base_value,
+            Attribute::Move => value -= self.encumberance(),
+            _ => {}
         }
+        value.max(0)
     }
 
     /// Calculates the malus to movement and reflexes based on encumberance
@@ -315,9 +353,16 @@ Character {{ \n\
     ///
     /// This will apply damage to the armor (outer to inner) and then to the character.
     ///
-    pub fn hit(&mut self, damage: i32, zone: HitZone, damage_type: DamageType) {
+    pub fn hit(
+        &mut self,
+        damage: i32,
+        zone: HitZone,
+        damage_type: DamageType,
+        is_gunshot: bool,
+        roller: &mut dyn DieRoller,
+    ) -> HitOutcome {
         let mut remaining_damage = damage;
-        let mut absorbed_damage = 0;
+        let mut soft_absorbed = 0;
 
         for i in (0..self.worn_armor.len()).rev() {
             let armor_uuid = self.worn_armor[i];
@@ -326,44 +371,100 @@ Character {{ \n\
                 .as_any_mut().downcast_mut::<Armor>();
             let armor = armor_opt.unwrap_or_else(|| panic!("There was an Armor in the worn_armor list ({}), that wasn't an Armor in the Inventory.",
                 armor_uuid));
+            let is_hard = armor.is_hard;
             let damage_result = armor.hit(remaining_damage, zone, damage_type);
             remaining_damage = damage_result.remaining_damage;
-            absorbed_damage += damage_result.absorbed_damage;
+            // House rule: only hits caught by SOFT armor go onto the bruise
+            // scale; hard armor absorbs without consequence.
+            if !is_hard {
+                soft_absorbed += damage_result.absorbed_damage;
+            }
         }
-        // House rule: 20% of absorbed damage becomes real damage through blunt trauma.
-        // TODO: implement variable for this so it rotates through subsequent hits as well.
-        // TODO: implement different handlings of DamageType (HollowPoint double damage)
-        // TODO: implement full penetration (can't do more then 4+1d10 damage, everything else goes out on the back)
-        remaining_damage += absorbed_damage / 5;
-        self.take_damage(remaining_damage, zone);
+
+        // House rule: a gunshot doing more than 4 damage rolls 1d10 — that is
+        // the maximum extra damage before the shot exits through the back.
+        let mut through_and_through = false;
+        if is_gunshot && remaining_damage > 4 {
+            let cap = 4 + roller.d10();
+            if remaining_damage > cap {
+                remaining_damage = cap;
+                through_and_through = true;
+            }
+        }
+
+        // TODO(Q17): HollowPoint/dum-dum double damage against soft targets —
+        // pending ruling on what exactly counts as a soft target.
+        let mut outcome = self.resolve_damage(remaining_damage, soft_absorbed, zone);
+        outcome.through_and_through = through_and_through;
+        outcome
     }
 
     /// This ignores all armor and applies damage directly.
     /// It will subtract the BTM first.
-    pub fn take_damage(&mut self, damage: i32, zone: HitZone) {
-        let mut remaining_damage = damage;
-        if remaining_damage > 0 {
-            remaining_damage = (remaining_damage - self.btm()).max(1);
+    pub fn take_damage(&mut self, damage: i32, zone: HitZone) -> HitOutcome {
+        self.resolve_damage(damage, 0, zone)
+    }
 
-            // TODO: Need to implement the House Rule that this doubling only takes effect after the check if it will kill you immediately.
-            if zone == HitZone::Head {
-                remaining_damage *= 2;
-            }
-            self.current_damage += remaining_damage;
-            if remaining_damage >= 8 {
-                if matches!(zone, HitZone::Head | HitZone::Chest | HitZone::Vitals) {
-                    self.current_damage = 100;
-                    self.damage_notes = format!("YOU ARE DEAD!\n{}", self.damage_notes);
-                } else {
-                    self.damage_notes = format!(
-                        "HitZone {} destroyed. You are now at least Mortal 0 and about to die.\n{}",
-                        zone, self.damage_notes
-                    );
-                    if self.current_damage <= 12 {
-                        self.current_damage = 13;
-                    }
+    /// Core damage resolution after armor: BTM conversion, bruise scale,
+    /// crippling check and head doubling.
+    ///
+    /// House rules applied here:
+    /// - BTM is subtracted from the incoming damage (at least 1 real damage
+    ///   remains) and the subtracted amount becomes Prellschaden.
+    /// - Every 5 Prellschaden points convert into 1 real damage and require a
+    ///   KO check. A hit that causes ONLY Prellschaden instead puts a malus of
+    ///   that amount on the character's next roll.
+    /// - The crippling check (8+ zone damage after BTM) uses the UNDOUBLED
+    ///   value; head doubling is applied afterwards.
+    fn resolve_damage(&mut self, incoming: i32, armor_bruise: i32, zone: HitZone) -> HitOutcome {
+        let mut real_damage = incoming.max(0);
+        let mut bruise = armor_bruise;
+
+        if real_damage > 0 {
+            let converted_by_btm = self.btm().min(real_damage - 1).max(0);
+            real_damage -= converted_by_btm;
+            bruise += converted_by_btm;
+        }
+
+        self.current_bruise += bruise;
+        let converted_bruise_damage = self.current_bruise / 5;
+        self.current_bruise %= 5;
+        let ko_check_required = converted_bruise_damage > 0;
+
+        if real_damage == 0 && converted_bruise_damage == 0 && bruise > 0 {
+            self.pending_roll_malus += bruise;
+        }
+
+        // Crippling check against the unmodified zone damage, doubling after.
+        let crippled = real_damage >= 8;
+        let mut applied_damage = real_damage;
+        if zone == HitZone::Head {
+            applied_damage *= 2;
+        }
+        applied_damage += converted_bruise_damage;
+        self.current_damage += applied_damage;
+
+        if crippled {
+            if matches!(zone, HitZone::Head | HitZone::Chest | HitZone::Vitals) {
+                self.current_damage = 100;
+                self.damage_notes = format!("YOU ARE DEAD!\n{}", self.damage_notes);
+            } else {
+                self.damage_notes = format!(
+                    "HitZone {} destroyed. You are now at least Mortal 0 and about to die.\n{}",
+                    zone, self.damage_notes
+                );
+                if self.current_damage <= 12 {
+                    self.current_damage = 13;
                 }
             }
+        }
+
+        HitOutcome {
+            real_damage: applied_damage,
+            bruise_added: bruise,
+            converted_bruise_damage,
+            ko_check_required,
+            through_and_through: false,
         }
     }
 
@@ -492,8 +593,10 @@ Character {{ \n\
             })?;
         let (attribute_value, skill_level) = (self.effective_attribute(skill.base), skill.level);
         self.spend_luck(luck)?;
+        // pure bruise damage puts a malus on the NEXT roll — consume it
+        let malus = std::mem::take(&mut self.pending_roll_malus);
         Ok(skill_check(
-            attribute_value,
+            attribute_value - malus,
             skill_level,
             luck,
             difficulty,
@@ -512,7 +615,14 @@ Character {{ \n\
     ) -> Result<CheckResult, String> {
         let attribute_value = self.effective_attribute(attribute);
         self.spend_luck(luck)?;
-        Ok(skill_check(attribute_value, 0, luck, difficulty, roller))
+        let malus = std::mem::take(&mut self.pending_roll_malus);
+        Ok(skill_check(
+            attribute_value - malus,
+            0,
+            luck,
+            difficulty,
+            roller,
+        ))
     }
 
     pub fn print_skills(&self) {
@@ -653,7 +763,8 @@ mod tests {
         let mut character = populated_character();
         let zone = HitZone::RightArm;
         let damage = 45;
-        character.hit(damage, zone, DamageType::Blunt);
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let outcome = character.hit(damage, zone, DamageType::Blunt, false, &mut roller);
         let test_context = "multi-layer-arm";
         assert_armor_protection(&character,test_context,"Kevlar Shirt",       zone,  0, HitZone::Chest,   10,);
         assert_armor_protection(&character,test_context,"Flak Vest",          zone, 19, HitZone::Chest,   20,);
@@ -663,12 +774,17 @@ mod tests {
         assert_armor_protection(&character,test_context,"Braces",             zone,  9, HitZone::LeftArm, 10,);
         assert_armor_protection(&character,test_context,"Helmet",             zone,  0, HitZone::Head,    15,);
 
-        let expected_armor_on_arm = 20 + 10 + 4;
-        let expected_blunt_trauma = expected_armor_on_arm / 5;
-        let body_type_modifier = 4;
-
-        let expected_damage = (damage - expected_armor_on_arm) + expected_blunt_trauma - body_type_modifier;
+        // soft armor on arm (braces 10 + cloak 4) = 14 -> Prellschaden
+        // hard armor on arm (flak vest) absorbs 20 without consequence
+        // remaining zone damage: 45 - 34 = 11; BTM 4 converts to Prellschaden -> 7 real
+        // 7 < 8: NOT crippling. Prellschaden 14 + 4 = 18 -> 3 real damage, scale at 3
+        let expected_damage = 7 + 3;
         assert_eq!(character.current_damage, expected_damage, "{}: Expected {} damage but was {}", test_context, expected_damage, character.current_damage);
+        assert_eq!(character.current_bruise, 3);
+        assert!(outcome.ko_check_required);
+        assert!(!outcome.through_and_through);
+        assert_eq!(character.pending_roll_malus, 0);
+        assert_eq!(character.damage_notes, "", "7 zone damage after BTM must not cripple");
     }
 
     #[test]
@@ -677,7 +793,8 @@ mod tests {
         let mut character = populated_character();
         let zone = HitZone::Head;
         let damage = 16;
-        character.hit(damage, zone, DamageType::Blunt);
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        character.hit(damage, zone, DamageType::Blunt, false, &mut roller);
         let test_context = "multi-layer-head";
         assert_armor_protection(&character,test_context,"Kevlar Shirt",       zone,  0, HitZone::Chest,   10,);
         assert_armor_protection(&character,test_context,"Flak Vest",          zone,  0, HitZone::Chest,   20,);
@@ -687,10 +804,8 @@ mod tests {
         assert_armor_protection(&character,test_context,"Braces",             zone,  0, HitZone::LeftArm, 10,);
         assert_armor_protection(&character,test_context,"Helmet",             zone, 14, HitZone::Vitals,   0,);
 
-        // armor on head: 15
-        // blunt trauma: 3
-        // body type modifier: 4 (but can't reduce lower than 0)
-        // damage on head is doubled
+        // hard helmet absorbs 15 without Prellschaden; 1 remains.
+        // BTM can't reduce below 1 real damage. Head damage is doubled.
 
         let expected_damage = 2;
         assert_eq!(character.current_damage, expected_damage, "{}: Expected {} damage but was {}", test_context, expected_damage, character.current_damage);
@@ -736,11 +851,10 @@ mod tests {
     fn test_take_crippling_head_damage() {
         let mut character = populated_character();
         let zone = HitZone::Head;
-        let damage = 8;
+        // 12 incoming - 4 BTM = 8 after BTM: crippling on the head means death.
+        let damage = 12;
         character.take_damage(damage, zone);
         let test_context = "crippling-head";
-
-        // damage of 8 or more is crippling on the head you just die, also damage is doubled.
 
         let expected_damage = 100;
         assert_eq!(
@@ -748,6 +862,111 @@ mod tests {
             "{}: Expected {} damage but was {}",
             test_context, expected_damage, character.current_damage
         );
+    }
+
+    #[test]
+    fn test_gunshot_penetration_cap() {
+        let mut character = unencumbered_shooter(); // BODY 10, BTM 4, no armor
+                                                    // 20 incoming, gunshot: cap roll d10 = 3 -> max 4 + 3 = 7 before through-and-through
+        let mut roller = crate::dice::SequenceRoller::new(vec![3]);
+        let outcome = character.hit(20, HitZone::Stomach, DamageType::Blunt, true, &mut roller);
+        assert!(outcome.through_and_through);
+        // capped at 7, BTM converts 4 -> 3 real damage + 4 bruise
+        assert_eq!(character.current_damage, 3);
+        assert_eq!(character.current_bruise, 4);
+    }
+
+    #[test]
+    fn test_melee_hit_is_not_capped() {
+        let mut character = unencumbered_shooter();
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let outcome = character.hit(20, HitZone::Stomach, DamageType::Blunt, false, &mut roller);
+        assert!(!outcome.through_and_through);
+        // 20 - BTM 4 = 16 real: 8+ -> stomach crippled, at least Mortal 0
+        assert!(outcome.real_damage >= 16);
+    }
+
+    #[test]
+    fn test_pure_bruise_hit_gives_next_roll_malus() {
+        let mut character = unencumbered_shooter();
+        // soft armor that swallows the whole hit
+        let vest = kev_shirt();
+        let vest_uuid = vest.item.uuid;
+        character.inventory.push(Box::new(vest));
+        character.wear_armor(vest_uuid, None);
+
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let outcome = character.hit(3, HitZone::Chest, DamageType::Blunt, true, &mut roller);
+        assert_eq!(outcome.real_damage, 0);
+        assert_eq!(outcome.bruise_added, 3);
+        assert!(!outcome.ko_check_required);
+        assert_eq!(character.pending_roll_malus, 3);
+
+        // the malus applies to exactly one (the next) roll and is then consumed
+        let mut roller = crate::dice::SequenceRoller::new(vec![5]);
+        let result = character
+            .check_skill("Pistole", 0, Difficulty::Normal, &mut roller)
+            .unwrap();
+        // REF 8 + Pistole 4 - malus 3 + die 5 = 14
+        assert_eq!(result.total, 14);
+        assert_eq!(character.pending_roll_malus, 0);
+    }
+
+    #[test]
+    fn test_bruise_scale_converts_every_five_points() {
+        let mut character = unencumbered_shooter();
+        let outcome = character.take_damage(0, HitZone::Chest);
+        assert_eq!(outcome.real_damage, 0);
+
+        // three hits of 3 damage each: BTM 4 can only convert damage-1 = 2
+        // -> each hit: 1 real damage + 2 bruise
+        for _ in 0..2 {
+            character.take_damage(3, HitZone::Chest);
+        }
+        assert_eq!(character.current_damage, 2);
+        assert_eq!(character.current_bruise, 4);
+
+        let outcome = character.take_damage(3, HitZone::Chest);
+        // third hit: bruise reaches 6 -> 1 converted damage, scale at 1
+        assert_eq!(outcome.converted_bruise_damage, 1);
+        assert!(outcome.ko_check_required);
+        assert_eq!(character.current_damage, 4);
+        assert_eq!(character.current_bruise, 1);
+    }
+
+    #[test]
+    fn test_wound_penalties_in_effective_attributes() {
+        let mut character = unencumbered_shooter(); // REF 8, INT 5, BODY 10
+        character.current_damage = 6; // Serious: -2 REF
+        assert_eq!(character.effective_attribute(Attribute::Reflexes), 6);
+        assert_eq!(character.effective_attribute(Attribute::Intelligence), 5);
+
+        character.current_damage = 10; // Critical: REF/INT/COOL halved, round up
+        assert_eq!(character.effective_attribute(Attribute::Reflexes), 4);
+        assert_eq!(character.effective_attribute(Attribute::Intelligence), 3);
+        assert_eq!(character.effective_attribute(Attribute::Body), 10);
+
+        character.current_damage = 14; // Mortal 0: thirds, except LUCK/EMP
+        assert_eq!(character.effective_attribute(Attribute::Reflexes), 3);
+        assert_eq!(character.effective_attribute(Attribute::Body), 4);
+        assert_eq!(character.effective_attribute(Attribute::Luck), 5);
+        assert_eq!(
+            character.wound_state(),
+            crate::health::WoundState::Mortal(0)
+        );
+    }
+
+    #[test]
+    fn test_head_damage_below_crippling_doubles_but_does_not_kill() {
+        let mut character = populated_character();
+        // 8 incoming - 4 BTM = 4 after BTM: below the crippling limit.
+        // The crippling check uses the UNDOUBLED value; the damage doubles after.
+        let outcome = character.take_damage(8, HitZone::Head);
+        assert_eq!(character.current_damage, 8);
+        assert_eq!(outcome.real_damage, 8);
+        assert_eq!(character.damage_notes, "");
+        // the 4 points BTM took went onto the bruise scale
+        assert_eq!(character.current_bruise, 4);
     }
 
     fn assert_armor_protection(

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,111 @@
+use crate::character::Attribute;
+
+/// Wound state per the house rules (Regeln → Gesundheit): health is divided
+/// into blocks of four hit points.
+///
+/// 1st block: scratches — no malus. 2nd block: serious wounds — −2 REF.
+/// 3rd block: critical — REF/INT/COOL halved (round up). Blocks 4–8: mortal
+/// wounds — all stats except LUCK and EMP divided by 3 (round up). Beyond the
+/// 8th block the body is too disintegrated to still count as human.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WoundState {
+    Uninjured,
+    /// 1–4 damage: scratches and minor stuff.
+    Light,
+    /// 5–8 damage: wounds and unpleasantness. −2 REF.
+    Serious,
+    /// 9–12 damage: critical injuries. REF/INT/COOL halved, round up.
+    Critical,
+    /// 13–32 damage: Mortal 0 through Mortal 4. All stats except LUCK and EMP
+    /// divided by 3, round up.
+    Mortal(i32),
+    /// More than 32 damage.
+    Dead,
+}
+
+impl WoundState {
+    pub fn from_damage(damage: i32) -> Self {
+        match damage {
+            ..=0 => WoundState::Uninjured,
+            1..=4 => WoundState::Light,
+            5..=8 => WoundState::Serious,
+            9..=12 => WoundState::Critical,
+            13..=32 => WoundState::Mortal((damage - 13) / 4),
+            _ => WoundState::Dead,
+        }
+    }
+
+    /// Applies this wound state's penalty to an attribute value.
+    /// Halving and thirding round up, as the house rules demand.
+    pub fn modify_attribute(self, attr: Attribute, value: i32) -> i32 {
+        match self {
+            WoundState::Uninjured | WoundState::Light => value,
+            WoundState::Serious => {
+                if attr == Attribute::Reflexes {
+                    value - 2
+                } else {
+                    value
+                }
+            }
+            WoundState::Critical => match attr {
+                Attribute::Reflexes | Attribute::Intelligence | Attribute::Coolness => {
+                    (value + 1) / 2
+                }
+                _ => value,
+            },
+            WoundState::Mortal(_) | WoundState::Dead => match attr {
+                Attribute::Luck | Attribute::Empathy => value,
+                _ => (value + 2) / 3,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wound_state_blocks() {
+        assert_eq!(WoundState::from_damage(0), WoundState::Uninjured);
+        assert_eq!(WoundState::from_damage(1), WoundState::Light);
+        assert_eq!(WoundState::from_damage(4), WoundState::Light);
+        assert_eq!(WoundState::from_damage(5), WoundState::Serious);
+        assert_eq!(WoundState::from_damage(8), WoundState::Serious);
+        assert_eq!(WoundState::from_damage(9), WoundState::Critical);
+        assert_eq!(WoundState::from_damage(12), WoundState::Critical);
+        assert_eq!(WoundState::from_damage(13), WoundState::Mortal(0));
+        assert_eq!(WoundState::from_damage(16), WoundState::Mortal(0));
+        assert_eq!(WoundState::from_damage(17), WoundState::Mortal(1));
+        assert_eq!(WoundState::from_damage(32), WoundState::Mortal(4));
+        assert_eq!(WoundState::from_damage(33), WoundState::Dead);
+    }
+
+    #[test]
+    fn test_serious_penalizes_only_reflexes() {
+        let state = WoundState::Serious;
+        assert_eq!(state.modify_attribute(Attribute::Reflexes, 8), 6);
+        assert_eq!(state.modify_attribute(Attribute::Intelligence, 8), 8);
+        assert_eq!(state.modify_attribute(Attribute::Move, 8), 8);
+    }
+
+    #[test]
+    fn test_critical_halves_ref_int_cool_rounding_up() {
+        let state = WoundState::Critical;
+        assert_eq!(state.modify_attribute(Attribute::Reflexes, 7), 4);
+        assert_eq!(state.modify_attribute(Attribute::Intelligence, 8), 4);
+        assert_eq!(state.modify_attribute(Attribute::Coolness, 5), 3);
+        assert_eq!(state.modify_attribute(Attribute::Body, 7), 7);
+        assert_eq!(state.modify_attribute(Attribute::Empathy, 7), 7);
+    }
+
+    #[test]
+    fn test_mortal_thirds_everything_except_luck_and_empathy() {
+        let state = WoundState::Mortal(0);
+        assert_eq!(state.modify_attribute(Attribute::Reflexes, 9), 3);
+        assert_eq!(state.modify_attribute(Attribute::Body, 7), 3);
+        assert_eq!(state.modify_attribute(Attribute::Intelligence, 4), 2);
+        assert_eq!(state.modify_attribute(Attribute::Luck, 9), 9);
+        assert_eq!(state.modify_attribute(Attribute::Empathy, 9), 9);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,16 @@
 mod armor;
 mod character;
 mod dice;
+mod health;
 mod inventory;
 mod weapons;
 
 pub use self::armor::{Armor, HitZone};
-pub use self::character::{Attribute, AttributeValue, Character, List, Skill};
+pub use self::character::{Attribute, AttributeValue, Character, HitOutcome, List, Skill};
 pub use self::dice::{open_roll, skill_check};
 pub use self::dice::{
     CheckResult, DieRoller, Difficulty, OpenRollResult, Outcome, RandomRoller, SequenceRoller,
 };
+pub use self::health::WoundState;
 pub use self::inventory::{Inventory, Item};
 pub use self::weapons::DamageType;

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,14 @@ fn character_test() {
         0,
     )));
     cool_guy.print();
-    cool_guy.hit(15, HitZone::Chest, DamageType::ArmorPiercing);
+    let mut roller = RandomRoller;
+    cool_guy.hit(
+        15,
+        HitZone::Chest,
+        DamageType::ArmorPiercing,
+        true,
+        &mut roller,
+    );
     cool_guy.print();
 
     cool_guy.print_skills();


### PR DESCRIPTION
Milestone M2 complete, per the rulings in PROJECT-STRUCTURE.md §3 (Q17–Q20 answered 2026-07-09):

**Prellschaden replaces the 20% approximation**
- `Character.current_bruise` (0–4): soft-armor absorbed damage goes on point-for-point (Q20 confirmed), hard armor absorbs without consequence
- BTM is subtracted from incoming damage **and converted** to Prellschaden, min 1 real damage remains
- Every 5 points → 1 real damage + `ko_check_required`; a hit causing *only* Prellschaden sets `pending_roll_malus`, consumed by the next check

**Penetration cap** — gunshots doing >4 remaining damage are capped at `4 + 1d10`, rest exits the back (`through_and_through`). `Character::hit` takes `is_gunshot` + `DieRoller`, returns `HitOutcome`.

**Head-hit ordering** — crippling check (8+ after BTM) uses the **undoubled** value; doubling after. `take_damage(8, Head)` vs BTM 4 no longer instant-kills.

**Hollow-point (Q17)** — mushrooms: halved vs hard armor, full damage vs soft armor (Prellschaden as usual), damage reaching flesh **doubles**, projectile never exits (no penetration cap). Test replays Ben's exact example (8 dmg vs 4-SP soft armor → 8−BTM reach the character).

**Wound states (new `health.rs`)** — blocks of 4: Light / Serious (−2 REF) / Critical (REF/INT/COOL halved ↑) / Mortal 0–4 (thirds, except LUCK+EMP) / Dead (>32); applied in `effective_attribute()` before encumbrance (Q19 confirmed).

**Healing (Q18)** — `rest_day(healer)`: 1/day with healer, 1 per two days without; `complication_check(healer, roller)`: morning-after BODY vs 10 + damage, skipped with a healer.

Wiki synced (Regeln: Dum-Dum precision + Heilung section) and snapshots refreshed.

Deferred to M3+: KO-check resolution mechanics, the 5%/0.5% crippling roll (both want the advantage/modifier system).

15 new tests, 61 total, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)