### PR TITLE
feat: KO check per wound-track stun maluses

### DIFF
--- a/AI-README.md
+++ b/AI-README.md
@@ -99,6 +99,15 @@ Each damage type has a private helper method. Full mechanics documented on publi
   full damage vs soft armor; damage reaching flesh DOUBLES and the projectile
   never exits (no penetration cap)
 
+### KO check ("Stun Save")
+- Any hit causing real damage sets `ko_check_required` (pure Prellschaden
+  gives the next-roll malus instead)
+- `Character::ko_check(roller)`: BODY (sheet value + advantage modifiers,
+  NOT wound-thirded — the category malus covers that) − Stun malus vs 10.
+  Stun malus per wound track: Light 0, Serious −1, Critical −2, Mortal n −(3+n)
+- Failure = out of the fight, may repeat every round, first success recovers;
+  critical failure = GM decides (usually out longer)
+
 ### Healing (Q18)
 - `Character::rest_day(healer_present)`: heals 1/day with healer, 1 per two
   days without (`healing_progress` carries the half-day)

--- a/PROJECT-STRUCTURE.md
+++ b/PROJECT-STRUCTURE.md
@@ -160,6 +160,11 @@ Design rules already established (keep them):
   10 + taken damage or complications arise — skipped entirely when a healer is
   present (practically always). Healing rate: 1 damage per two days, with a
   healer 1 per day.
+- **KO check** *(decided 2026-07-09)*: after taking real damage, BODY vs 10,
+  modified by the wound category's Stun malus (character sheet wound track:
+  Light 0, Serious −1, Critical −2, Mortal n −(3+n)). Failure = out of the
+  fight (KO, screaming, …), may repeat every round, first success = recovered.
+  Critical failure = GM decides, usually out longer.
 - Fire damage ignores the ">8 damage" rule.
 
 ### Encumbrance (`character.rs`, `inventory.rs`) — implemented, #12 ✓

--- a/docs/rules/Regeln.wiki
+++ b/docs/rules/Regeln.wiki
@@ -72,6 +72,13 @@ Am Morgen nach einer Verwundung: BODY-Wurf gegen 10 + erlittenen Schaden, sonst 
 
 Geheilt wird ein Punkt alle zwei Tage; mit Heiler ein Punkt pro Tag.
 
+=== KO-Check ===
+Nach erlittenem (echtem) Schaden: BODY-Wurf gegen 10, modifiziert um die Schadenskategorie (Leicht −0, Schwer −1, Kritisch −2, Tödlich 0 −3, jede weitere Tödlich-Stufe −1 mehr — siehe Wound Track auf dem Charakterbogen).
+
+Misslingt der Wurf, ist der Charakter aus dem Kampf (KO, schreiend am Boden, wimmernd, …). Der Wurf darf jede Runde wiederholt werden; mit dem ersten Erfolg ist der Charakter erholt und wieder handlungsfähig. Bei einem kritischen Patzer entscheidet der SL — meistens ist man länger raus.
+
+Reiner Prellschaden erfordert keinen KO-Check (gibt stattdessen den Abzug auf den nächsten Wurf).
+
 ===Spezial===
 
 ==== Durchschlag bei Schusswaffen ====

--- a/src/character.rs
+++ b/src/character.rs
@@ -152,7 +152,8 @@ pub struct HitOutcome {
     /// Real damage that came from the bruise scale filling up
     /// (already part of `real_damage`).
     pub converted_bruise_damage: i32,
-    /// The bruise scale converted to real damage: a KO check is required.
+    /// The hit caused real damage (directly or via a full bruise scale):
+    /// a KO check is required, see [`Character::ko_check`].
     pub ko_check_required: bool,
     /// The penetration cap kicked in: the shot exited through the back.
     pub through_and_through: bool,
@@ -352,6 +353,25 @@ Character {{ \n\
         }
     }
 
+    /// The KO check after taking damage: BODY against 10, modified by the
+    /// wound category's Stun malus (Light −0, Serious −1, Critical −2,
+    /// Mortal 0 −3, one more per Mortal step).
+    ///
+    /// Uses the sheet BODY (plus advantage modifiers) WITHOUT the wound
+    /// thirding — the category malus already covers the wound effect;
+    /// applying both would double-count.
+    ///
+    /// On a failure the character is out of the fight (KO, on the floor
+    /// screaming, …) and may repeat the roll every round; the first success
+    /// means recovery. On a critical failure the GM decides — usually out
+    /// for longer.
+    pub fn ko_check(&self, roller: &mut dyn DieRoller) -> CheckResult {
+        let body = self.attributes.get(&Attribute::Body).unwrap().actual
+            + self.modifier_for_attribute(Attribute::Body)
+            - self.wound_state().ko_malus();
+        skill_check(body, 0, 0, Difficulty::Custom(10), roller)
+    }
+
     /// The morning-after complication check: BODY against 10 + current damage.
     /// With a healer present (practically always) no check is needed and
     /// `None` is returned. A failed check means complications — interpreting
@@ -528,7 +548,9 @@ Character {{ \n\
         self.current_bruise += bruise;
         let converted_bruise_damage = self.current_bruise / capacity;
         self.current_bruise %= capacity;
-        let ko_check_required = converted_bruise_damage > 0;
+        // taking real damage requires a KO check (see Character::ko_check);
+        // pure Prellschaden doesn't — it gives the next-roll malus instead
+        let ko_check_required = real_damage > 0 || converted_bruise_damage > 0;
 
         if real_damage == 0 && converted_bruise_damage == 0 && bruise > 0 {
             self.pending_roll_malus += bruise;
@@ -1269,6 +1291,54 @@ mod tests {
         );
         assert_eq!(character.modifier_for_tag("hören"), 2);
         assert_eq!(character.modifier_for_tag("sehen"), 0);
+    }
+
+    #[test]
+    fn test_ko_check_maluses_follow_wound_track() {
+        let mut character = unencumbered_shooter(); // BODY 10
+
+        // uninjured: BODY 10 vs 10 -> auto-success, no roll needed
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let result = character.ko_check(&mut roller);
+        assert_eq!(result.outcome, crate::dice::Outcome::AutoSuccess);
+
+        // Serious (Stun -1): BODY 9 + die 2 = 11 vs 10 -> recovers
+        character.current_damage = 6;
+        let mut roller = crate::dice::SequenceRoller::new(vec![2]);
+        assert!(character.ko_check(&mut roller).outcome.is_success());
+
+        // Mortal 2 (Stun -5): BODY 5 + die 4 = 9 -> stays down this round...
+        character.current_damage = 22;
+        let mut roller = crate::dice::SequenceRoller::new(vec![4]);
+        assert!(!character.ko_check(&mut roller).outcome.is_success());
+        // ...but may repeat every round and recovers on the first success
+        let mut roller = crate::dice::SequenceRoller::new(vec![5]);
+        assert!(character.ko_check(&mut roller).outcome.is_success());
+
+        // critical failure is reported for the GM to decide (out for longer)
+        let mut roller = crate::dice::SequenceRoller::new(vec![1, 1]);
+        assert_eq!(
+            character.ko_check(&mut roller).outcome,
+            crate::dice::Outcome::CriticalFailure
+        );
+    }
+
+    #[test]
+    fn test_real_damage_requires_ko_check() {
+        let mut character = unencumbered_shooter();
+        let outcome = character.take_damage(6, HitZone::Chest);
+        assert!(outcome.ko_check_required);
+
+        // pure Prellschaden: no KO check, next-roll malus instead
+        let mut character = unencumbered_shooter();
+        let vest = kev_shirt();
+        let vest_uuid = vest.item.uuid;
+        character.inventory.push(Box::new(vest));
+        character.wear_armor(vest_uuid, None);
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let outcome = character.hit(3, HitZone::Chest, DamageType::Blunt, true, &mut roller);
+        assert!(!outcome.ko_check_required);
+        assert_eq!(character.pending_roll_malus, 3);
     }
 
     #[test]

--- a/src/health.rs
+++ b/src/health.rs
@@ -35,6 +35,21 @@ impl WoundState {
         }
     }
 
+    /// The KO-check ("Stun Save") malus of this wound state, per the CP2020
+    /// wound track on the character sheet: Light −0, Serious −1, Critical −2,
+    /// Mortal 0 −3 and one more per Mortal step.
+    pub fn ko_malus(self) -> i32 {
+        match self {
+            WoundState::Uninjured | WoundState::Light => 0,
+            WoundState::Serious => 1,
+            WoundState::Critical => 2,
+            WoundState::Mortal(step) => 3 + step,
+            // a dead character has no KO check to make; the malus only keeps
+            // the arithmetic sane if it is ever queried
+            WoundState::Dead => 9,
+        }
+    }
+
     /// Applies this wound state's penalty to an attribute value.
     /// Halving and thirding round up, as the house rules demand.
     pub fn modify_attribute(self, attr: Attribute, value: i32) -> i32 {


### PR DESCRIPTION
Implements the KO check per Ben's ruling (closes the last M2 deferral):

- `Character::ko_check(roller)`: **BODY vs 10**, modified by the wound category's Stun malus from the character-sheet wound track — Light −0, Serious −1, Critical −2, Mortal n −(3+n)
- Uses the sheet BODY (+ advantage modifiers) **without** the Mortal wound-thirding — the Stun malus already encodes the wound effect; applying both would double-count
- Failure = out of the fight (KO / on the floor screaming); the roll may be repeated every round, first success = recovered. A **critical failure** is reported as such for the GM to decide (usually out longer)
- `HitOutcome.ko_check_required` now fires on **any real damage** ("after taking damage the player rolls"), not just bruise conversion; pure Prellschaden still gives the next-roll malus instead
- BODY 10 while uninjured auto-succeeds (base ≥ target — the tough don't flinch)

Wiki synced: Regeln has a new *KO-Check* section; snapshot refreshed.

2 new tests (75 total, all passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)