### PR TITLE
docs: batch open questions Q21-Q31 for M4-M7

### DIFF
--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -2,24 +2,9 @@
 
 Standing Q&A file: Claude collects questions here so Ben can answer them in one
 go; answered questions are folded into PROJECT-STRUCTURE.md (marked *(decided)*)
-and removed. Q1–Q31 are answered (Q31 = M7 on hold until Ben decides hosting).
+and removed.
 
-## Non-blocking (answer whenever)
-
-**Q32 — In-play skill-leveling cost formula.** Two data points conflict:
-the Charaktererschaffung page says 7→8 costs 40 CP in play, your Q23 example
-says Nahkampf Kurz 3→4 costs 40 XP. (new level × 10 fits the second, × 5 the
-first.) Not blocking anything — XP tracking is a player thing and out of scope —
-but the tool can't validate in-play level-ups until this is settled.
-
-## FYI — working assumptions for the unattended run (veto in PR review)
-
-- **Lifepath source**: the core manual PDF is a scan without text layer, so I
-  implement the lifepath from Reference Book 5's collated "Expanded Character
-  Creation" tables (which include the RAW core tables). Anything that looks
-  expanded-only gets flagged in the PR.
-- **Missing RB5 weapons**: Sling, Lance/Spear and Molotov cocktail have no
-  Reference Book 5 entries; they get plausible RAW-consistent best-guess stats,
-  clearly marked for review (same pattern as the trait catalog, Q30).
-- **DAM table** (melee damage modifier), from RB5: BODY 2 → −2, 3-4 → −1,
-  5-7 → 0, 8-9 → +1, 10 → +2, 11-12 → +4, 13-14 → +6, 15+ → +8.
+**No open questions right now.** (Q1–Q32 answered; Q31 = M7 on hold until Ben
+decides hosting. Standing instruction: report any contradictions between RB5
+values and other sources — wiki, sheet, earlier rulings — instead of silently
+picking one.)

--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -2,7 +2,76 @@
 
 Standing Q&A file: Claude collects questions here so Ben can answer them in one
 go; answered questions are folded into PROJECT-STRUCTURE.md (marked *(decided)*)
-and removed.
+and removed. Q1–Q20 are answered; batch below collected 2026-07-09 so work can
+continue through M4–M7 without check-ins.
 
-**No open questions right now.** (Q1–Q20 answered; decisions live in
-PROJECT-STRUCTURE.md, section 3.)
+## Confirmations (implemented, veto if wrong)
+
+**Q21 — KO-check BODY basis.** `ko_check()` uses the sheet BODY (+ advantage
+modifiers) minus the wound-track Stun malus — WITHOUT the Mortal thirding,
+since the Stun malus already encodes the wound effect and applying both would
+double-count. (Merged in PR #30; flagging for the record.)
+
+## Damage / healing leftovers
+
+**Q22 — Crippling roll timing (5% / 0.5%).** "Critical or worse injuries have
+a 5% crippling chance without proper medical care (0.5% with care; Schnelle
+Heilung lowers to 1% / 0.1%)." When is that rolled — once per qualifying
+injury at the moment it's taken, or during healing (e.g. with the
+morning-after complication check)? And what does "crippled" mean mechanically
+for the tool — permanent note on the zone, attribute reduction, both?
+
+## M4 — Skills with special functions (#15)
+
+**Q23 — Melee specialization levels.** A character has Nahkampf allgemein 3
+and then specializes. Does "Kurz 2" mean effective level 5 (3 general + 2
+specialization stack), or does the specialization CONTINUE the scale (buying
+level 4, 5, …) so the effective level is just the specialization value? What
+do rolls with medium/long weapons use for this character — general 3?
+
+**Q24 — Dodge placement.** "Nahkampf allgemein enthält Ausweichen" — after
+specializing, does Dodge stay on the general level (3) forever, or does it
+grow with a specialization?
+
+**Q25 — Unfamiliar weapon "+3 auf den Wurf".** The wiki sentence reads like a
+BONUS for unfamiliar weapons ("bekommt man +3 auf den Wurf, durch das
+allgemeine Wissen über Waffen"). I assume it means the roll is made at a
+DIFFICULTY +3 (i.e. −3 effectively), or that one rolls with only a base +3
+instead of the full skill. Which is it?
+
+**Q26 — Martial arts styles & damage scaling.** Which styles exist at your
+table (wiki names Prügeln, Boxen, Ringen) and which key attacks does each
+have? And "skill level scales damage" — how exactly (e.g. Strike 1d3 + DAM +
+skill level? level added to damage rolls? something else)? The DAM values I
+can take from the CP2020 sheet/RAW unless yours differ.
+
+## M5 — Weapons (#21)
+
+**Q27 — Weapon catalog scope.** Import the full CP2020 RAW weapon list from
+Reference Book 5 as a data file, or a curated TL6-appropriate list for your
+post-desaster world (AK-47, Grach, hunting rifles, shotguns, bows, melee …)?
+If curated: rough list of what exists in-world would help.
+
+**Q28 — Weapon stats that matter.** Planned fields: damage dice, damage type,
+ROF/burst modes, magazine size, range, reliability, concealability, weight,
+attachments (silencer/scope). Anything else your table actually uses —
+e.g. availability/rarity for the workshop trading system?
+
+## M6 — Chargen (#9)
+
+**Q29 — Lifepath depth.** Should the tool implement the CP2020 RAW lifepath
+tables (roll per year over 15) with your post-apocalyptic reinterpretation as
+editable text results — or keep lifepath freeform (text only) and only
+implement the mechanical parts (attributes, skill points, age points, budget,
+advantages)?
+
+**Q30 — Trait catalog.** OK if I encode all ~65 wiki Vor-/Nachteile as a TOML
+data file with my best-guess modifiers (mechanical ones tagged, narrative ones
+plain), for you to review in the PR diff?
+
+## M7 — Web service (planning ahead)
+
+**Q31 — Hosting target.** What runs on your server (Docker? bare systemd?
+reverse proxy?), and how should players authenticate — simple shared password,
+per-user accounts, something existing (e.g. forum/Nextcloud SSO)? This shapes
+whether I build a simple axum binary with a token or something bigger.

--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -2,76 +2,24 @@
 
 Standing Q&A file: Claude collects questions here so Ben can answer them in one
 go; answered questions are folded into PROJECT-STRUCTURE.md (marked *(decided)*)
-and removed. Q1–Q20 are answered; batch below collected 2026-07-09 so work can
-continue through M4–M7 without check-ins.
+and removed. Q1–Q31 are answered (Q31 = M7 on hold until Ben decides hosting).
 
-## Confirmations (implemented, veto if wrong)
+## Non-blocking (answer whenever)
 
-**Q21 — KO-check BODY basis.** `ko_check()` uses the sheet BODY (+ advantage
-modifiers) minus the wound-track Stun malus — WITHOUT the Mortal thirding,
-since the Stun malus already encodes the wound effect and applying both would
-double-count. (Merged in PR #30; flagging for the record.)
+**Q32 — In-play skill-leveling cost formula.** Two data points conflict:
+the Charaktererschaffung page says 7→8 costs 40 CP in play, your Q23 example
+says Nahkampf Kurz 3→4 costs 40 XP. (new level × 10 fits the second, × 5 the
+first.) Not blocking anything — XP tracking is a player thing and out of scope —
+but the tool can't validate in-play level-ups until this is settled.
 
-## Damage / healing leftovers
+## FYI — working assumptions for the unattended run (veto in PR review)
 
-**Q22 — Crippling roll timing (5% / 0.5%).** "Critical or worse injuries have
-a 5% crippling chance without proper medical care (0.5% with care; Schnelle
-Heilung lowers to 1% / 0.1%)." When is that rolled — once per qualifying
-injury at the moment it's taken, or during healing (e.g. with the
-morning-after complication check)? And what does "crippled" mean mechanically
-for the tool — permanent note on the zone, attribute reduction, both?
-
-## M4 — Skills with special functions (#15)
-
-**Q23 — Melee specialization levels.** A character has Nahkampf allgemein 3
-and then specializes. Does "Kurz 2" mean effective level 5 (3 general + 2
-specialization stack), or does the specialization CONTINUE the scale (buying
-level 4, 5, …) so the effective level is just the specialization value? What
-do rolls with medium/long weapons use for this character — general 3?
-
-**Q24 — Dodge placement.** "Nahkampf allgemein enthält Ausweichen" — after
-specializing, does Dodge stay on the general level (3) forever, or does it
-grow with a specialization?
-
-**Q25 — Unfamiliar weapon "+3 auf den Wurf".** The wiki sentence reads like a
-BONUS for unfamiliar weapons ("bekommt man +3 auf den Wurf, durch das
-allgemeine Wissen über Waffen"). I assume it means the roll is made at a
-DIFFICULTY +3 (i.e. −3 effectively), or that one rolls with only a base +3
-instead of the full skill. Which is it?
-
-**Q26 — Martial arts styles & damage scaling.** Which styles exist at your
-table (wiki names Prügeln, Boxen, Ringen) and which key attacks does each
-have? And "skill level scales damage" — how exactly (e.g. Strike 1d3 + DAM +
-skill level? level added to damage rolls? something else)? The DAM values I
-can take from the CP2020 sheet/RAW unless yours differ.
-
-## M5 — Weapons (#21)
-
-**Q27 — Weapon catalog scope.** Import the full CP2020 RAW weapon list from
-Reference Book 5 as a data file, or a curated TL6-appropriate list for your
-post-desaster world (AK-47, Grach, hunting rifles, shotguns, bows, melee …)?
-If curated: rough list of what exists in-world would help.
-
-**Q28 — Weapon stats that matter.** Planned fields: damage dice, damage type,
-ROF/burst modes, magazine size, range, reliability, concealability, weight,
-attachments (silencer/scope). Anything else your table actually uses —
-e.g. availability/rarity for the workshop trading system?
-
-## M6 — Chargen (#9)
-
-**Q29 — Lifepath depth.** Should the tool implement the CP2020 RAW lifepath
-tables (roll per year over 15) with your post-apocalyptic reinterpretation as
-editable text results — or keep lifepath freeform (text only) and only
-implement the mechanical parts (attributes, skill points, age points, budget,
-advantages)?
-
-**Q30 — Trait catalog.** OK if I encode all ~65 wiki Vor-/Nachteile as a TOML
-data file with my best-guess modifiers (mechanical ones tagged, narrative ones
-plain), for you to review in the PR diff?
-
-## M7 — Web service (planning ahead)
-
-**Q31 — Hosting target.** What runs on your server (Docker? bare systemd?
-reverse proxy?), and how should players authenticate — simple shared password,
-per-user accounts, something existing (e.g. forum/Nextcloud SSO)? This shapes
-whether I build a simple axum binary with a token or something bigger.
+- **Lifepath source**: the core manual PDF is a scan without text layer, so I
+  implement the lifepath from Reference Book 5's collated "Expanded Character
+  Creation" tables (which include the RAW core tables). Anything that looks
+  expanded-only gets flagged in the PR.
+- **Missing RB5 weapons**: Sling, Lance/Spear and Molotov cocktail have no
+  Reference Book 5 entries; they get plausible RAW-consistent best-guess stats,
+  clearly marked for review (same pattern as the trait catalog, Q30).
+- **DAM table** (melee damage modifier), from RB5: BODY 2 → −2, 3-4 → −1,
+  5-7 → 0, 8-9 → +1, 10 → +2, 11-12 → +4, 13-14 → +6, 15+ → +8.

--- a/PROJECT-STRUCTURE.md
+++ b/PROJECT-STRUCTURE.md
@@ -233,6 +233,8 @@ authoritative source since it is not on the wiki)*
   age 16→1 … 24→9, 25→11, 26→13, 27→15, 28→17, 29→20, 30→23, 31→26, 32→29).
 - Skill costs at creation: level N costs N points cumulative-per-level
   (1,2,3 …). Caps: one skill at 8, one at 7, two at 6 — tradeable 1:2 downward.
+- In-play skill raises *(decided, Q32)*: **target level × 10 CP** (7→8 = 80 CP;
+  the wiki's old "40" was wrong and is fixed).
 - Reading/writing is a 5/10 CP advantage; higher education 15 CP and gates
   academic skills (2 levels allowed without it, given fitting background).
 - Starting equipment budget = (sum of levels of three profession-defining skills,

--- a/PROJECT-STRUCTURE.md
+++ b/PROJECT-STRUCTURE.md
@@ -160,11 +160,15 @@ Design rules already established (keep them):
   10 + taken damage or complications arise — skipped entirely when a healer is
   present (practically always). Healing rate: 1 damage per two days, with a
   healer 1 per day.
-- **KO check** *(decided 2026-07-09)*: after taking real damage, BODY vs 10,
-  modified by the wound category's Stun malus (character sheet wound track:
-  Light 0, Serious −1, Critical −2, Mortal n −(3+n)). Failure = out of the
-  fight (KO, screaming, …), may repeat every round, first success = recovered.
-  Critical failure = GM decides, usually out longer.
+- **KO check** *(decided 2026-07-09, Q21 confirmed)*: after taking real damage,
+  BODY vs 10, modified by the wound category's Stun malus (character sheet
+  wound track: Light 0, Serious −1, Critical −2, Mortal n −(3+n)); sheet BODY,
+  no wound thirding. Failure = out of the fight (KO, screaming, …), may repeat
+  every round, first success = recovered. Critical failure = GM decides.
+- **Crippling roll** *(decided, Q22)*: rolled directly AFTER the fight, once
+  per critical-or-worse injury — 5% without proper medical care, 0.5% with
+  (Schnelle Heilung: 1% / 0.1%). What "crippled" means has no direct rule; the
+  tool reports the result, the GM decides based on the situation.
 - Fire damage ignores the ">8 damage" rule.
 
 ### Encumbrance (`character.rs`, `inventory.rs`) — implemented, #12 ✓
@@ -182,12 +186,24 @@ authoritative source since it is not on the wiki)*
 
 - All melee skills are "Nahkampf allgemein" (general melee, includes Dodge) up to
   level 3; above that they split into short / medium / long weapon classes.
-  *(decided: "general" is only the shared level 1–3 base, not a fourth branch.)*
-  Full skill only with accustomed weapons; unfamiliar weapon class → +3 difficulty.
-- Martial arts: named styles (Prügeln/brawling, boxing, wrestling …) with key
-  attacks (Strike 1d3+DAM, Kick 1d6+DAM, Block, Dodge, Disarm, Grapple, Throw
-  1d6+DAM + stun check −2, Hold +1/round, Escape, Choke 1d6/round); skill level
-  scales damage.
+  *(decided, Q23)*: each specialization CONTINUES the scale independently from
+  the shared base. Example: Nahkampf allgemein 3, then Kurz bought to 4 → rolls
+  1d10+4 with short weapons, 1d10+3 with medium/long; raising Mittel to 4 is a
+  separate purchase.
+- *(decided, Q24)*: Dodge stays on the general level (caps at 3). Whether the
+  explicit Ausweichen skill should base on general melee is undecided — for now
+  it doesn't.
+- *(decided, Q25)*: unfamiliar weapons within a known class → difficulty +3
+  (the wiki's "+3 auf den Wurf" was an incomplete sentence; general weapon
+  knowledge means part of the skill still applies).
+- Martial arts *(decided, Q26)*: styles at the table with key-attack bonuses —
+  **Prügeln** (none), **Boxen** (+3 Punch, +3 Sweep, +1 Block), **Ringen**
+  (+2 Sweep, +4 Grapple, +3 Throw, +4 Hold, +2 Choke, +4 Escape). Key-attack
+  bonuses add to the attack roll; the skill level is added 1:1 to damage.
+  Base actions per wiki: Strike/Punch 1d3+DAM, Kick 1d6+DAM, Sweep, Block,
+  Dodge, Disarm, Grapple, Throw 1d6+DAM (stun check −2), Hold (+1/round),
+  Escape, Choke (1d6/round). DAM per RB5 hand-to-hand table (BODY 2 → −2 …
+  10 → +2, 11-12 → +4, 13-14 → +6, 15+ → +8).
 - Role/class special abilities are abolished — they are ordinary skills
   (Authority→COOL, Interface→INT, Jury Rig→TECH, Meditech→TECH, Leadership) or
   advantages (Charisma, Combat Sense) or replaced by reputation (Credibility,
@@ -209,7 +225,10 @@ authoritative source since it is not on the wiki)*
 - Lifepath: for each year of age above 15, optionally roll "did something
   interesting happen" — *(decided: this is the CP2020 RAW lifepath system,
   GM-interpreted into the post-apocalyptic setting)* — or write a history by
-  hand (no boni, no mali).
+  hand (no boni, no mali). *(decided, Q29)*: implement the RAW lifepath tables
+  with a variant toggle (e.g. `chargen --classic` vs `chargen --desaster`) so
+  differently flavored table sets can be added later. Source: RB5's collated
+  Expanded Character Creation section (core manual is a text-less scan).
 - Skill points = INT + REF + 40 + age points (table in `docs/rules/Alterspunkte.wiki`:
   age 16→1 … 24→9, 25→11, 26→13, 27→15, 28→17, 29→20, 30→23, 31→26, 32→29).
 - Skill costs at creation: level N costs N points cumulative-per-level
@@ -225,9 +244,15 @@ authoritative source since it is not on the wiki)*
 ### Weapons (`weapons.rs`) — for #21
 
 - Stats come from **CP2020 RAW** (`docs/pdf/Cyberpunk 2020 - Reference Book 5.pdf`,
-  git-ignored local copy).
+  git-ignored local copy). *(decided, Q27)*: one representative per category
+  from the issue list; with multiple candidates pick a MIDDLE one (knife →
+  Combat Knife, not Knife and not Kendachi Monoknife). Sling, lance and Molotov
+  have no RB5 entries → best-guess stats marked for review.
 - Categories from issue #21: knives, clubs, axes, lances, brass knuckles, pistols,
   SMGs, rifles, shotguns, bows, rocket launcher, sling, shuriken, Molotov cocktail.
+- *(decided, Q28)*: availability/rarity/cost fields STAY — the tool should also
+  serve classical CP2020 settings, not just the post-desaster campaign; expect
+  this dual-setting support to grow.
 - Attachments: silencer, scope.
 - AK damage *(decided/verified in Reference Book 5)*: the classic AK-47/AKM is
   **5d6** (7.62sov, 30 mag, ROF 20, Very Reliable, 400 m) — the table plays 5d6.
@@ -278,19 +303,22 @@ The workshop trade system IS in scope.)*
 - **M3 — Dis-/advantages (#10)**: *done 2026-07-09* — storage with CP budget
   validation plus generic `Modifier` mechanism (attribute / skill-by-name /
   free tag) wired into checks, initiative, bruise scale and healing rate.
-  Not done: a data file cataloguing all ~65 wiki traits (fits better with
-  chargen, M6); KO-check resolution still pending.
-- **M4 — Skills special functions (#15)**: melee split at level 3, martial-arts
-  actions with scaled damage.
-- **M5 — Weapons (#21)**: Weapon as InventoryItem, categories from RAW stats,
-  fire modes, attachments, noise formula.
-- **M6 — Character generation (#9)**: point-buy validation, age points, lifepath,
-  equipment budget; then randomized NSC generation on top.
-- **M7 — Frontend**: long-term goal is a **web service hosted on Ben's server**:
-  players (and Ben) update characters through it, the server auto-rolls things
-  like full-auto attacks, and **AI agents can interact with it** (clean HTTP API,
-  possibly MCP). Design consequence: keep the rules engine a pure library with a
-  thin API layer; the current CLI `main.rs` stays a dev playground until then.
+  KO check landed separately (PR #30). Crippling roll (Q22) → M4 or M6.
+- **M4 — Skills special functions (#15)**: melee split at level 3 with
+  independently-continued specializations (Q23), Dodge capped on general (Q24),
+  unfamiliar-weapon +3 difficulty (Q25), martial-arts styles Prügeln/Boxen/
+  Ringen with key attacks and 1:1 skill-level damage (Q26), DAM table.
+- **M5 — Weapons (#21)**: Weapon as InventoryItem, one middle-of-the-road RAW
+  representative per category (Q27), availability/rarity/cost kept for classic
+  CP2020 support (Q28), fire modes, attachments, noise formula.
+- **M6 — Character generation (#9)**: point-buy validation, age points, RAW
+  lifepath with variant toggle --classic/--desaster (Q29), equipment budget,
+  trait catalog as reviewable TOML with best-guess modifiers (Q30); then
+  randomized NSC generation on top.
+- **M7 — Frontend**: **ON HOLD (Q31)** — Ben hasn't decided hosting/auth yet.
+  Long-term goal remains a web service on Ben's server with auto-rolls and an
+  AI-agent-friendly API; keep the rules engine a pure library with a thin API
+  layer; the current CLI `main.rs` stays a dev playground until then.
 - **M8 — Campaign tools**: workshop equipment-token trade simulator (in scope);
   no XP tracking.
 

--- a/docs/rules/Regeln.wiki
+++ b/docs/rules/Regeln.wiki
@@ -128,10 +128,10 @@ Dabei kommt es auf die Situation an wo die Schäden entstehen. Feuerschaden igno
 ====Niederknüppeln====
 Hat man keine Schusswaffen zur Hand kann man immer die nächste Schlagwaffe nehmen und es damit versuchen. In einer Welt in der starke Rüstung selten ist kommt man damit wahrscheinlich sogar ziemlich weit.
 
-Sie kommen in den Fertigkeiten: Kampfkunst, Kurze Waffen (Messer, etc.), Mittlere Waffen (Schwerter, Knüppel etc.) und lange Waffen (Speere, Kampfstäbe). Dabei bekommt man den vollen Skill nur auf Waffen die man gewöhnt ist, nutzt man eine Waffenart die man nicht gewohnt ist bekommt man +3 auf den Wurf, durch das Allgemeine Wissen über Waffen, abtrainierte Hemmschwelle etc.
+Sie kommen in den Fertigkeiten: Kampfkunst, Kurze Waffen (Messer, etc.), Mittlere Waffen (Schwerter, Knüppel etc.) und lange Waffen (Speere, Kampfstäbe). Dabei bekommt man den vollen Skill nur auf Waffen, die man gewöhnt ist. Nutzt man eine Waffe, die man nicht gewohnt ist, ist die Schwierigkeit um 3 erhöht — durch das allgemeine Wissen über Waffen, abtrainierte Hemmschwelle etc. bleibt ein Teil der Fähigkeit noch bestehen.
 
 =====Kampfkunstaktionen=====
-Es gibt die Kampfkunst Prügeln, ansonsten kann man auch eine systematisiertere (Ringen oder Boxen) Lernen.
+Es gibt die Kampfkunst Prügeln (keine Key Attacks), ansonsten kann man eine systematisiertere lernen: Boxen (+3 Punch, +3 Sweep, +1 Block) oder Ringen (+2 Sweep, +4 Grapple, +3 Throw, +4 Hold, +2 Choke, +4 Escape). Die Key-Attack-Boni gelten auf den Angriffswurf; der Fertigkeitswert wird 1:1 auf den Schaden addiert.
 Die Fähigkeit Ausweichen kann man zusätzlich einsetzen um dem Schaden ganz zu entgehen.
 
 * Strike: 1d3+ Bodymodifier Schaden (Kopf, Torso, Arme)

--- a/docs/rules/charaktererschaffung.wiki
+++ b/docs/rules/charaktererschaffung.wiki
@@ -18,7 +18,7 @@ Dann vergibt man seine Punkte auf die Fertigkeiten, dabei kostet jeder Level ein
 
 Es ist erlaubt: eine Fertigkeit mit Wert 8, eine mit Wert 7, zwei mit Wert 6, darunter frei. Dabei kann man 1:2 nach unten tauschen (also drei mit 7, zwei mit 6 ist auch okay, dafür dann eben keinen mit 8).
 
-: Für den Min-Maxer: Während des Spiels ist es etwas schwieriger hohe Skills zu erwerben. Von 7 -> 8 kostet bei der Erschaffung einen Punkt, im Spiel kostet es 40 CP (bei ~5 / Abend). Man möge das im Kopf behalten.
+: Für den Min-Maxer: Während des Spiels ist es etwas schwieriger hohe Skills zu erwerben. Von 7 -> 8 kostet bei der Erschaffung einen Punkt, im Spiel kostet eine Steigerung Ziellevel × 10 CP (7 -> 8 also 80 CP, bei ~5 / Abend). Man möge das im Kopf behalten.
 
 Zuletzt kauft man sich sein Equipment. Dabei wird der Fertigkeitslevel von drei berufsdefinierenden Fertigkeiten genommen, und mit 350 multipliziert. Für einen Tech wäre das  "Basic Tech", "Elektrotechnik" und "Schweißen" oder was auch immer, für einen Nomaden wahrscheinlich "Fahren: LKW", "Fahren: Auto" und "Schießen: Gewehr". Welche drei Skills das sind kann sich der Spieler aussuchen, ich habe ein Veto-Recht.
 

--- a/docs/rules/hausregeln.wiki
+++ b/docs/rules/hausregeln.wiki
@@ -1,7 +1,7 @@
 == Fertigkeiten ==
-Alle Nahkampffertigkeiten sind bis Stufe 3 "Nahkampf allgemein" danach getrennt nach Kurz/Mittel/Lang.
+Alle Nahkampffertigkeiten sind bis Stufe 3 "Nahkampf allgemein" danach getrennt nach Kurz/Mittel/Lang. Jede Spezialisierung setzt die Skala unabhängig fort. Beispiel: Nahkampf allgemein 3, dann Kurz auf 4 gekauft → 1W10+4 mit kurzen Waffen, 1W10+3 mit mittleren und langen. Mittel auf 4 muss separat gekauft werden.
 
-Nahkampf allgemein enthält Ausweichen.
+Nahkampf allgemein enthält Ausweichen (bleibt damit bei maximal 3).
 == Punktevergabe ==
 '''Meisterpunkte''': Ich vergebe die Grundpunkte für den Abenteuerfortschritt: 3 - 8 Punkte.
 
@@ -39,7 +39,7 @@ Der Body Type Modifier (BTM) wird vom ankommenden Schaden abgezogen und in Prell
 
 Wenn eine Schusswaffe mehr als 4 Punkte Schaden macht wird mit 1d10 gewürfelt. Soviel extra Schaden kann dieser Schuss noch anrichten bevor es ein Durchschuss wird.
 
-Eine Verletzung vom Typ "Kritisch" oder darüber hat eine 5% Chance auf Verkrüppelung des entsprechenden Körperteils wenn nicht besondere Medizinische Hilfe geleistet wird. (5/1000 wenn diese geleistet wird).
+Eine Verletzung vom Typ "Kritisch" oder darüber hat eine 5% Chance auf Verkrüppelung des entsprechenden Körperteils wenn nicht besondere Medizinische Hilfe geleistet wird. (5/1000 wenn diese geleistet wird). Gewürfelt wird direkt nach dem Kampf; was die Verkrüppelung konkret bedeutet, entscheidet der SL nach Situation.
 
 Kopftrefferschaden wird verdoppelt, aber die Frage ob man daran stirbt ist verändert. Siehe [[Regeln]].
 


### PR DESCRIPTION
~~Questions Q21–Q31 for M4–M7.~~ **All answered by Ben (2026-07-09) and folded in.** This PR now contains:

- **PROJECT-STRUCTURE.md §3** updated with every ruling, marked *(decided)*: crippling roll directly after the fight; melee specializations continue the scale independently from the shared general-3 base; Dodge caps on general; unfamiliar weapons = +3 difficulty; martial-arts styles Prügeln / Boxen (+3 Punch, +3 Sweep, +1 Block) / Ringen (+2 Sweep, +4 Grapple, +3 Throw, +4 Hold, +2 Choke, +4 Escape) with skill level added 1:1 to damage; weapon catalog = middle-of-the-road RAW representatives with availability/cost kept for classic-CP2020 support; RAW lifepath with a `--classic`/`--desaster` variant toggle; trait catalog as reviewable best guesses; **M7 on hold** pending hosting decision.
- **Wiki synced** (Regeln + Hausregeln): the incomplete unfamiliar-weapons sentence completed per Ben, martial-arts styles with key attacks, the specialization example (general 3 / Kurz 4 → 1d10+4 short, 1d10+3 medium), crippling-roll timing. Snapshots refreshed.
- **OPEN-QUESTIONS.md** down to Q32 (non-blocking: in-play skill-leveling cost — 7→8=40 vs 3→4=40 conflict) plus documented working assumptions for the unattended run: lifepath source is RB5's collated tables (core manual is a text-less scan), and Sling/Lance/Molotov get flagged best-guess stats (no RB5 entries).

Source-material verification done: RB5 contains the lifepath tables, the hand-to-hand DAM table (BODY 2 → −2 … 15+ → +8) and all other weapon entries (Combat Knife 1d6+3, Brass Knuckles 1d6+2, shuriken, bows, LAW …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)