### PR TITLE
feat: M4-M6 — special skills, weapons, character creation

### DIFF
--- a/AI-README.md
+++ b/AI-README.md
@@ -212,6 +212,29 @@ Encumbrance affects:
 - `Character::crippling_check(medical_care, roller)`: rolled once per
   critical+ injury directly after the fight; 5%/0.5%, Schnelle Heilung 1%/0.1%.
 
+## Weapons (`weapons.rs`) — #21
+
+- `Weapon` (InventoryItem, serde: `item` field LAST for TOML) with category,
+  WA, concealability, availability, damage `DiceExpr`, damage type, magazine,
+  ROF, reliability, range, silencer/scope flags. Availability/cost kept for
+  classic-CP2020 support (Q28).
+- `Weapon::catalog()`: one middle RAW representative per issue-#21 category
+  (Q27); comments carry the RB5 source line. Sling + Molotov = BEST GUESS
+  (no RB5 entry), marked in the comment.
+- `DamageType::Fire` (new): armor protects like Blunt, never cripples
+  (>8-rule ignored), used by the Molotov.
+- `Character::check_ranged_attack(weapon, skill, ...)` adds WA (+1 scope);
+  `Character::weapon_damage()` adds DAM for melee-class weapons.
+- Autofire: `autofire_attack_modifier(bullets, close)` = ±1 per 10 bullets,
+  `autofire_hits(total, target, bullets)` = margin capped at bullets.
+  Burst: `BURST_ATTACK_BONUS` (+3), `burst_hits()` = 1d2.
+- `shot_noise_bonus(weapon, bullets, distance, walls, soundproofed)`:
+  avg×3 (silencer halves), −2/wall, −6/soundproofed, −2/50m, +2/bullet.
+  NOTE: the wiki's 200m AK example says 38 but the formula gives 37 (wiki
+  arithmetic typo).
+- When adding InventoryItem types: extend SerializeableInventoryItem + both
+  Serialize/Deserialize impls in inventory.rs.
+
 ## Dis-/Advantages (`advantages.rs`) — #10
 
 - `Advantage { name, kind, cp (always positive), level, description, modifiers }`;

--- a/AI-README.md
+++ b/AI-README.md
@@ -191,6 +191,27 @@ Encumbrance affects:
 
 ---
 
+## Melee & Martial Arts (`melee.rs`) — #15
+
+- General melee skill "Nahkampf" (incl. Dodge) caps at 3 (`MELEE_GENERAL_CAP`);
+  specializations "Nahkampf Kurz/Mittel/Lang" CONTINUE the scale independently.
+  `Character::melee_level(class)` = specialization if present, else general
+  (capped). `check_melee(class, familiar, ...)`: unfamiliar weapon = target +3.
+  `check_dodge()` always uses general (Q24).
+- Martial arts: styles Prügeln (no key attacks), Boxen (+3 Punch/+3 Sweep/
+  +1 Block), Ringen (+2 Sweep/+4 Grapple/+3 Throw/+4 Hold/+2 Choke/+4 Escape).
+  `check_martial_arts(style, action, ...)` adds the key-attack bonus to the
+  roll; `martial_arts_damage()` = base dice (Punch 1d3, Kick/Throw/Choke 1d6)
+  + DAM (not for Choke) + skill level 1:1.
+- `Character::dam()` = hand-to-hand DAM from sheet BODY (RB5 table:
+  ..2 → −2, 3-4 → −1, 5-7 → 0, 8-9 → +1, 10 → +2, 11-12 → +4, 13-14 → +6,
+  15+ → +8). Distinct from `btm()` (damage reduction when hit)!
+- `dice::DiceExpr` ("5d6+2"): parse/display/roll/average (integer halving —
+  matches wiki noise examples); `DieRoller::die(sides)` for non-d10 dice;
+  `roll_per_mille()` for the crippling check.
+- `Character::crippling_check(medical_care, roller)`: rolled once per
+  critical+ injury directly after the fight; 5%/0.5%, Schnelle Heilung 1%/0.1%.
+
 ## Dis-/Advantages (`advantages.rs`) — #10
 
 - `Advantage { name, kind, cp (always positive), level, description, modifiers }`;

--- a/AI-README.md
+++ b/AI-README.md
@@ -250,6 +250,30 @@ Encumbrance affects:
 - Situational tags ("hören", …): caller queries `modifier_for_tag()` when a
   fitting roll comes up.
 
+## Character Creation (`chargen.rs`) — #9
+
+- Validations: `validate_attributes` (60 points, 2..=9 each, INT/REF ≥ 5, no
+  10 at creation), `validate_skill_caps` (one 8 / one 7 / two 6, tradeable
+  1:2 downward), `validate_skill_budget` (pool = INT + REF + 40 + age points;
+  skill level N costs N cumulative; advantages cost CP 1:1, disadvantages
+  grant), `validate_character` aggregates. `starting_money` = 3 profession
+  skills × 350 eb, Reich tag doubles the factor per level.
+- `age_points`: Alterspunkte table; >32 continues +3/year (aging rules #22
+  still unwritten).
+- **Lifepath** (Q29): data-driven d10 tables in `data/lifepath_classic.toml`
+  and `..._desaster.toml` (embedded via include_str!). Tables chain via
+  `goto`. `roll_background` (family/childhood/personality once) +
+  `roll_life_events` (one master roll per year over 15).
+  The classic file is a BEST-EFFORT transcription (core book is a text-less
+  scan) — marked for review; the desaster file starts as a copy to edit.
+- `generate_nsc(name, role, age, variant, roller)`: valid random attributes +
+  lifepath; skills/gear stay empty (GM flavor). CLI:
+  `cargo run -- chargen [--classic|--desaster] [name] [role] [age]`.
+- **Trait catalog** (Q30): `advantage_catalog()` loads all wiki traits from
+  `data/advantages.toml`; GUESS comments mark my modifier interpretations,
+  ENGINE-TODO marks rules needing engine hooks (half-Prellschaden, RUN factor,
+  Pech's always-fail-on-1, Bluter). Leveled traits encoded at smallest level.
+
 ## Quick Reference
 
 | What | Where |

--- a/PROJECT-STRUCTURE.md
+++ b/PROJECT-STRUCTURE.md
@@ -306,17 +306,20 @@ The workshop trade system IS in scope.)*
   validation plus generic `Modifier` mechanism (attribute / skill-by-name /
   free tag) wired into checks, initiative, bruise scale and healing rate.
   KO check landed separately (PR #30). Crippling roll (Q22) → M4 or M6.
-- **M4 — Skills special functions (#15)**: melee split at level 3 with
-  independently-continued specializations (Q23), Dodge capped on general (Q24),
-  unfamiliar-weapon +3 difficulty (Q25), martial-arts styles Prügeln/Boxen/
-  Ringen with key attacks and 1:1 skill-level damage (Q26), DAM table.
-- **M5 — Weapons (#21)**: Weapon as InventoryItem, one middle-of-the-road RAW
-  representative per category (Q27), availability/rarity/cost kept for classic
-  CP2020 support (Q28), fire modes, attachments, noise formula.
-- **M6 — Character generation (#9)**: point-buy validation, age points, RAW
-  lifepath with variant toggle --classic/--desaster (Q29), equipment budget,
-  trait catalog as reviewable TOML with best-guess modifiers (Q30); then
-  randomized NSC generation on top.
+- **M4 — Skills special functions (#15)**: *done 2026-07-10* — melee split at
+  level 3 with independently-continued specializations (Q23), Dodge capped on
+  general (Q24), unfamiliar-weapon +3 difficulty (Q25), martial-arts styles
+  Prügeln/Boxen/Ringen with key attacks and 1:1 skill-level damage (Q26),
+  DAM table, crippling roll (Q22).
+- **M5 — Weapons (#21)**: *done 2026-07-10* — Weapon as InventoryItem, one
+  middle RAW representative per category (Q27; Sling/Molotov = best guesses),
+  availability/cost kept for classic CP2020 support (Q28), DamageType::Fire,
+  autofire/burst helpers, noise formula (wiki example has an off-by-one typo:
+  AK at 200 m gives 37, not 38).
+- **M6 — Character generation (#9)**: *done 2026-07-10* — point-buy/caps/budget
+  validation, age points, data-driven lifepath with --classic/--desaster
+  toggle (Q29; classic tables are a best-effort transcription, REVIEW), money,
+  trait catalog as reviewable TOML (Q30), NSC skeleton generation.
 - **M7 — Frontend**: **ON HOLD (Q31)** — Ben hasn't decided hosting/auth yet.
   Long-term goal remains a web service on Ben's server with auto-rolls and an
   AI-agent-friendly API; keep the rules engine a pure library with a thin API

--- a/PROJECT-STRUCTURE.md
+++ b/PROJECT-STRUCTURE.md
@@ -320,10 +320,16 @@ The workshop trade system IS in scope.)*
   validation, age points, data-driven lifepath with --classic/--desaster
   toggle (Q29; classic tables are a best-effort transcription, REVIEW), money,
   trait catalog as reviewable TOML (Q30), NSC skeleton generation.
-- **M7 — Frontend**: **ON HOLD (Q31)** — Ben hasn't decided hosting/auth yet.
-  Long-term goal remains a web service on Ben's server with auto-rolls and an
-  AI-agent-friendly API; keep the rules engine a pure library with a thin API
-  layer; the current CLI `main.rs` stays a dev playground until then.
+- **M7 — Frontend**: scoped as **EPIC #33** (2026-07-10), implementation
+  **ON HOLD (Q31: hosting/auth undecided)**. Sub-issues in priority order:
+  #34 character maintenance UI live + PDF (*first*), #35 news tracker with
+  propagation (merchants carry news; AI-agent collaboration; replaces Ben's
+  Gnumeric sheet), #37 random encounters (post-apoc adaptation of the Night
+  City list), #38 loot generation (refresh the ~150-item list), #39 session
+  log with tags (replaces the Fandom diary; unified with the character sheet),
+  #36 automated full-auto rolls (*lowest*). Ben has detailed requirements per
+  step, to be collected when each sub-issue starts. Ground rule: rules engine
+  stays a pure library, thin agent-friendly API on top.
 - **M8 — Campaign tools**: workshop equipment-token trade simulator (in scope);
   no XP tracking.
 

--- a/data/advantages.toml
+++ b/data/advantages.toml
@@ -1,0 +1,654 @@
+# Vor- und Nachteile-Katalog (Q30) aus docs/rules/VorUndNachteile.wiki.
+#
+# Jede mechanische Wirkung ist ein GUESS-Kommentar + Modifier; rein narrative
+# Einträge haben keine Modifier (der SL spielt sie aus). Bei gestuften Traits
+# ist die KLEINSTE Stufe kodiert (cp/level); höhere Stufen klont man mit
+# with_level und skaliert die Modifier. "ENGINE-TODO" = die Regel bräuchte
+# einen Motor-Haken, den es noch nicht gibt.
+# BITTE die GUESS-Zeilen reviewen.
+
+# ============================= VORTEILE =============================
+
+# GUESS: Verdopplung von INT/TECH-Skillpunkten ist Chargen-Mechanik, kein
+# Roll-Modifier; Erinnerungswurf (INT gegen 10) macht der SL situativ.
+[[advantages]]
+name = "Absolutes Gedächtnis"
+kind = "Advantage"
+cp = 60
+level = 1
+description = "INT/TECH-Skillpunkte zählen doppelt; INT-Wurf gegen 10 für akkurate Erinnerung."
+modifiers = []
+
+# GUESS: kein Abzug für die schwache Hand — der Motor kennt (noch) keinen
+# Beidhändigkeits-Malus, daher narrativ.
+[[advantages]]
+name = "Beidhändig"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "Kein Abzug für die schwächere Hand."
+modifiers = []
+
+[[advantages]]
+name = "Bekanntes Gesicht"
+kind = "Advantage"
+cp = 5
+level = 1
+description = "Sieht aus wie eine bekannte Persönlichkeit (10 CP: klingt auch so, imitierbar)."
+modifiers = []
+
+# GUESS: Tag 'prellschaden' vergrößert die Skala 1:1 pro Level (2 CP/Punkt).
+[[advantages]]
+name = "Erhöhte Ausdauer"
+kind = "Advantage"
+cp = 2
+level = 1
+description = "Mehr Kleintreffer aushalten, bevor es auf die Gesundheit geht (2 CP/Punkt)."
+modifiers = [{ value = 1, target = { type = "Tag", of = "prellschaden" } }]
+
+# GUESS: −2 ATTR fest; +1 auf kurze 3D-Sicht als Tag 'dreidimensional'.
+[[advantages]]
+name = "Erweitertes Sichtfeld"
+kind = "Advantage"
+cp = 1
+level = 1
+description = "210° Sichtfeld; weit auseinanderstehende Augen (−2 ATTR), +1 bei 3D-Nahsicht."
+modifiers = [
+    { value = -2, target = { type = "Attribute", of = "Attractiveness" } },
+    { value = 1, target = { type = "Tag", of = "dreidimensional" } },
+]
+
+[[advantages]]
+name = "Fortschrittlich"
+kind = "Advantage"
+cp = 5
+level = 1
+description = "Aufgewachsen in höherem TL (5 CP/TL über 6); schaltet dortige Fertigkeiten frei."
+modifiers = []
+
+# GUESS: Tag 'angst' +2 (1 CP für 2 Level; 4 CP für 4 Level analog).
+[[advantages]]
+name = "Furchtlos"
+kind = "Advantage"
+cp = 1
+level = 2
+description = "Bonus auf alle Proben gegen Erschrecken/Einschüchtern/Angst."
+modifiers = [{ value = 2, target = { type = "Tag", of = "angst" } }]
+
+# GUESS: Tag 'gelenkigkeit' +3 (Ritzen, Schlingen, Klettern je nach Situation).
+[[advantages]]
+name = "Gelenkigkeit"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "+3 wo Beweglichkeit zählt (enge Ritzen, Fesseln, Klettern)."
+modifiers = [{ value = 3, target = { type = "Tag", of = "gelenkigkeit" } }]
+
+[[advantages]]
+name = "Gute Ohren"
+kind = "Advantage"
+cp = 1
+level = 2
+description = "Bonus auf Lausch-Wahrnehmung (1 CP für 2 Level, 4 CP für 4)."
+modifiers = [{ value = 2, target = { type = "Tag", of = "hören" } }]
+
+[[advantages]]
+name = "Gute Augen"
+kind = "Advantage"
+cp = 1
+level = 2
+description = "Bonus auf Seh-Wahrnehmung (1 CP für 2 Level, 4 CP für 4)."
+modifiers = [{ value = 2, target = { type = "Tag", of = "sehen" } }]
+
+[[advantages]]
+name = "Gute Nase"
+kind = "Advantage"
+cp = 1
+level = 2
+description = "Bonus auf Riechen/Schmecken (1 CP für 2 Level, 4 CP für 4)."
+modifiers = [{ value = 2, target = { type = "Tag", of = "riechen" } }]
+
+# GUESS: Tag 'tiere' +3; Ehrenkodex 'Tiere nicht quälen' ist narrativ dabei.
+[[advantages]]
+name = "Tierempathie"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "+3 auf alles mit Tieren; Kodex: Tiere nicht quälen."
+modifiers = [{ value = 3, target = { type = "Tag", of = "tiere" } }]
+
+[[advantages]]
+name = "Höhere Bildung"
+kind = "Advantage"
+cp = 15
+level = 1
+description = "Universitätszugang gehabt; schaltet akademische Fertigkeiten frei (setzt Lesen 10 CP voraus)."
+modifiers = []
+
+# GUESS: 10-CP-Version kodiert (+5 auf Langzeit-Würfe); 20 CP = würfelt nie
+# gegen Krankheiten (narrativ, Minimum BODY 6).
+[[advantages]]
+name = "Immun gegen Krankheiten"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "Zäh gegen Krankheiten: +5 auf Langzeiteffekt-Würfe (20 CP: nie krank)."
+modifiers = [{ value = 5, target = { type = "Tag", of = "krankheit" } }]
+
+# GUESS: leichte Version kodiert (+3); große Version = level 2 mit +6.
+# Wahrnehmung in Konflikten als eigener Tag.
+[[advantages]]
+name = "Kampfreflexe"
+kind = "Advantage"
+cp = 5
+level = 1
+description = "+3 Initiative und Konflikt-Wahrnehmung (10 CP: +6)."
+modifiers = [
+    { value = 3, target = { type = "Tag", of = "initiative" } },
+    { value = 3, target = { type = "Tag", of = "konflikt-wahrnehmung" } },
+]
+
+[[advantages]]
+name = "Konzentriert"
+kind = "Advantage"
+cp = 2
+level = 2
+description = "Bonus gegen Ablenkung (2 CP für 2 Level, 8 CP für 4); addiert zu Furchtlos."
+modifiers = [{ value = 2, target = { type = "Tag", of = "ablenkung" } }]
+
+[[advantages]]
+name = "Lesen und Schreiben"
+kind = "Advantage"
+cp = 5
+level = 1
+description = "Mühsam lesen (5 CP) oder flüssig (10 CP); Voraussetzung für Bildung."
+modifiers = []
+
+[[advantages]]
+name = "Maschinenflüsterer"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "+3 auf Wartung/Reparatur/Pflege von Maschinen und Fehlersuche (min. 15 CP in Maschinen-Skills)."
+modifiers = [{ value = 3, target = { type = "Tag", of = "maschinen" } }]
+
+[[advantages]]
+name = "Mathematische Begabung"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "+3 auf Kopfrechnen (auch Physik, höhere Mathematik, Chemie)."
+modifiers = [{ value = 3, target = { type = "Tag", of = "kopfrechnen" } }]
+
+[[advantages]]
+name = "Musikalische Begabung"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "+3 auf alles Musikalische."
+modifiers = [{ value = 3, target = { type = "Tag", of = "musik" } }]
+
+# GUESS: narrativ — 'keine Abzüge bei schlechtem Licht nach 5 Minuten' ist ein
+# Erlass von Situationsmali, kein fester Bonus.
+[[advantages]]
+name = "Nachtsicht"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "Keine Abzüge bei schlechtem Licht (nach 5 Min. Gewöhnung); völlige Finsternis bleibt."
+modifiers = []
+
+# GUESS: Tag 'reich' = Level; chargen::starting_money verdoppelt den Faktor
+# pro Punkt (0: 350, 1: 700, 2: 1400 …).
+[[advantages]]
+name = "Reich"
+kind = "Advantage"
+cp = 2
+level = 1
+description = "Verdoppelt den Startgeld-Faktor pro Level (SL-Veto je nach Hintergrund)."
+modifiers = [{ value = 1, target = { type = "Tag", of = "reich" } }]
+
+[[advantages]]
+name = "Richtungssinn"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "Wege der letzten ~4 Wochen auswendig; +3 wo Richtung zählt."
+modifiers = [{ value = 3, target = { type = "Tag", of = "richtung" } }]
+
+# GUESS: +3 Aushalten/Folter als Tag; halber Prellschaden und halbe
+# Verletzungsabzüge sind ENGINE-TODO (kein Haken vorhanden).
+[[advantages]]
+name = "Schmerzunempfindlich"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "+3 Aushalten/Folter; Prellschaden und Verletzungsabzüge zählen halb (ENGINE-TODO)."
+modifiers = [{ value = 3, target = { type = "Tag", of = "aushalten" } }]
+
+[[advantages]]
+name = "Schnelle Heilung"
+kind = "Advantage"
+cp = 5
+level = 1
+description = "Heilt Verletzungen doppelt so schnell; Verkrüppelung nur 1% / 0,1%."
+modifiers = [{ value = 1, target = { type = "Tag", of = "heilrate" } }]
+
+# GUESS: Scheintot-Mechanik ist narrativ/SL-Sache; pro Stufe ein 'Tödlich'-
+# Bereich markiert.
+[[advantages]]
+name = "Schwer zu töten"
+kind = "Advantage"
+cp = 5
+level = 1
+description = "Pro Stufe: ein Tödlich-Bereich wird bei misslungenem Tot-Check zu Scheintod."
+modifiers = []
+
+# GUESS: Chargen-Mechanik (Sprachpunkte verdoppelt/verdreifacht), narrativ.
+[[advantages]]
+name = "Sprachbegabung"
+kind = "Advantage"
+cp = 2
+level = 1
+description = "Alle Punkte in Sprachen verdoppelt (6 CP: verdreifacht)."
+modifiers = []
+
+[[advantages]]
+name = "Stimme"
+kind = "Advantage"
+cp = 10
+level = 1
+description = "+3 wo Stimme und Sprechen wichtig sind."
+modifiers = [{ value = 3, target = { type = "Tag", of = "stimme" } }]
+
+# GUESS: cp variabel — 0 als Platzhalter, der SL setzt den Preis.
+[[advantages]]
+name = "Ungewöhnlicher Hintergrund"
+kind = "Advantage"
+cp = 0
+level = 1
+description = "Zugriff auf normalerweise unverfügbare Fertigkeiten/Besitztümer; Kosten variabel (SL)."
+modifiers = []
+
+# ============================= NACHTEILE =============================
+
+[[advantages]]
+name = "Abergläubisch"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Richtet sein Leben nach Omen (5/10/15 CP nach Schwere); muss ausgespielt werden."
+modifiers = []
+
+# GUESS: die wichtigsten Mali als Tags; Sonnen-Schaden ist narrativ/SL.
+[[advantages]]
+name = "Albinismus"
+kind = "Disadvantage"
+cp = 15
+level = 1
+description = "Sonnenschaden, auffällig (−6 in Menge verstecken), −6 helles Licht, −5 räumlich, −4 sonstiges Sehen."
+modifiers = [
+    { value = -6, target = { type = "Tag", of = "sehen-hell" } },
+    { value = -4, target = { type = "Tag", of = "sehen" } },
+]
+
+[[advantages]]
+name = "Altruismus"
+kind = "Disadvantage"
+cp = 10
+level = 1
+description = "Stellt Forschungs-/Berufsergebnisse uneigennützig zur Verfügung (braucht Forschungs-Skill +4)."
+modifiers = []
+
+[[advantages]]
+name = "Ängste"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Phobien u.ä., Kosten nach Häufigkeit und Einschränkung; COOL-Wurf zum Überwinden."
+modifiers = []
+
+[[advantages]]
+name = "Arm"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Startet fast besitzlos (10 CP: dauerhaft Pech beim Güter-Ansammeln)."
+modifiers = []
+
+# GUESS: Heilungs-Stopp ist ENGINE-TODO (rest_day kennt kein 'heilt nie').
+[[advantages]]
+name = "Bluter"
+kind = "Disadvantage"
+cp = 50
+level = 1
+description = "Wunden heilen nicht von selbst und verschlimmern sich; innere Verletzungen tödlich (ENGINE-TODO)."
+modifiers = []
+
+[[advantages]]
+name = "Blutgier"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Will Gegner TOT sehen; COOL gegen 15 (gute Gründe: 10) um es zu lassen."
+modifiers = []
+
+[[advantages]]
+name = "Ehrenkodex"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Folgt festen Regeln der sozialen Gruppe (5–10 CP nach Einschränkung)."
+modifiers = []
+
+[[advantages]]
+name = "Ehrlich"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Kann nicht lügen; COOL 10 um zu schweigen, COOL 15 um doch zu lügen."
+modifiers = []
+
+# GUESS: −1 Tiefenschärfe, −2 im Kampf/hektisch, −2 ATTR fest.
+[[advantages]]
+name = "Einäugig"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Nur ein Auge: −1 Tiefenschärfe, −2 wenn es schnell gehen muss, meist −2 ATTR."
+modifiers = [
+    { value = -1, target = { type = "Tag", of = "dreidimensional" } },
+    { value = -2, target = { type = "Attribute", of = "Attractiveness" } },
+]
+
+[[advantages]]
+name = "Einarmig"
+kind = "Disadvantage"
+cp = 10
+level = 1
+description = "Zweiarmige Aktionen nur mit −6 oder gar nicht."
+modifiers = [{ value = -6, target = { type = "Tag", of = "zweihändig" } }]
+
+[[advantages]]
+name = "Einhändig"
+kind = "Disadvantage"
+cp = 3
+level = 1
+description = "Eine Hand fehlt (Haken/Messer-Prothese möglich); −2 auf zweihändige Aktionen."
+modifiers = [{ value = -2, target = { type = "Tag", of = "zweihändig" } }]
+
+# GUESS: −4 Handeln außerhalb des Expertenwissens und −4 Foltern als Tags;
+# 'durchschaut nie Lügen' ist narrativ.
+[[advantages]]
+name = "Empathielos"
+kind = "Disadvantage"
+cp = 10
+level = 1
+description = "Liest keine Gefühle: durchschaut nie Lügen, −4 Handeln (ohne Expertise), −4 Foltern."
+modifiers = [{ value = -4, target = { type = "Tag", of = "handeln" } }]
+
+[[advantages]]
+name = "Feige"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Weicht Verletzungsgefahr aus; COOL 10/15 um zu handeln (15 CP wenn Mut erwartet wird)."
+modifiers = []
+
+[[advantages]]
+name = "Farbenblind"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "−4 wo Farben nötig sind (Karten, Elektrotechnik), −2 wo nützlich (Spuren, Handeln)."
+modifiers = [{ value = -4, target = { type = "Tag", of = "farben" } }]
+
+# GUESS: doppelte Erschöpfung wäre ENGINE-TODO (Prellschaden durch Anstrengung
+# ist nicht automatisiert); +2 auf Festhalten/liegen bleiben als Tag.
+[[advantages]]
+name = "Fett"
+kind = "Disadvantage"
+cp = 10
+level = 1
+description = "BMI > 31: schneller außer Atem (ENGINE-TODO), keine normale Kleidung, +2 auf Festpinnen."
+modifiers = [{ value = 2, target = { type = "Tag", of = "festhalten" } }]
+
+[[advantages]]
+name = "Gefürchtetes Gesicht"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Sieht aus wie ein Gesuchter; Leute halten Abstand (10 CP: wird verwechselt/gejagt)."
+modifiers = []
+
+[[advantages]]
+name = "Geheimnis"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Muss etwas Gravierendes verheimlichen (10 CP: tödlich, wenn es rauskommt)."
+modifiers = []
+
+[[advantages]]
+name = "Großmaul"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Schmückt Geschichten über sich selbst aus; kein Lügner, nur größer als er ist."
+modifiers = []
+
+[[advantages]]
+name = "Hedonist"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Sucht Genuss, meidet Entbehrung, gibt Geld aus solange es hält."
+modifiers = []
+
+[[advantages]]
+name = "Humorlos"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Versteht keinen Humor, meint alles ernst."
+modifiers = []
+
+[[advantages]]
+name = "Impulsiv"
+kind = "Disadvantage"
+cp = 10
+level = 1
+description = "Less talking, more action: nimmt den ersten nicht offensichtlich dummen Plan."
+modifiers = []
+
+[[advantages]]
+name = "Intolerant"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Abneigung gegen Andersartige; COOL 10 (10 CP: 13) für distanzierte Höflichkeit."
+modifiers = []
+
+[[advantages]]
+name = "Kampfstarre"
+kind = "Disadvantage"
+cp = 15
+level = 1
+description = "Bei drohendem Schaden COOL gegen 13, sonst handlungsunfähig; +1 je weitere Runde."
+modifiers = []
+
+[[advantages]]
+name = "Kein Geruchs- und Geschmackssinn"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Nur Grundgeschmäcker, kein Geruch: erkennt weder Gift am Geschmack noch Rauch."
+modifiers = []
+
+# GUESS: RUN-Faktor 2 statt 3 ist ENGINE-TODO (Bewegungsweiten sind nicht
+# implementiert); Rest narrativ.
+[[advantages]]
+name = "Klein"
+kind = "Disadvantage"
+cp = 15
+level = 1
+description = "≤120 cm: fällt immer auf, RUN-Faktor 2 statt 3 (ENGINE-TODO)."
+modifiers = []
+
+[[advantages]]
+name = "Langsame Heilung"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Heilt Verletzungen nur mit halber Rate; Heildrogen wirken normal."
+modifiers = [{ value = -1, target = { type = "Tag", of = "heilrate" } }]
+
+[[advantages]]
+name = "Lebensmüde"
+kind = "Disadvantage"
+cp = 15
+level = 1
+description = "Keine Wertschätzung fürs eigene Wohlergehen; INT gegen 15 um sich zu schützen."
+modifiers = []
+
+[[advantages]]
+name = "Leichtgläubig"
+kind = "Disadvantage"
+cp = 10
+level = 1
+description = "Glaubt alles; lügt selbst nur mit −2 und merkt nicht, ob man ihm glaubt."
+modifiers = [{ value = -2, target = { type = "Tag", of = "lügen" } }]
+
+# GUESS: cp variabel — 5 als Platzhalter.
+[[advantages]]
+name = "Markenzeichen"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Hinterlässt immer 'seine' Spur; CP nach Risiko und Zeitaufwand."
+modifiers = []
+
+[[advantages]]
+name = "Muss fertig werden"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Kann Angefangenes nicht liegen lassen; COOL 15/20 (+5 wenn das Leben dranhängt)."
+modifiers = []
+
+[[advantages]]
+name = "Neugierde"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Will alles sofort erkunden; COOL 10 (steigend) um es zu lassen."
+modifiers = []
+
+[[advantages]]
+name = "Pazifist"
+kind = "Disadvantage"
+cp = 15
+level = 1
+description = "Lehnt Gewalt ab, schießt nie zuerst, kämpft nicht gegen Aufgebende."
+modifiers = []
+
+# GUESS: 'eine gewürfelte 1 misslingt IMMER (auch bei Auto-Erfolg)' wäre ein
+# ENGINE-TODO im Würfelmotor; narrativ kodiert.
+[[advantages]]
+name = "Pech"
+kind = "Disadvantage"
+cp = 10
+level = 1
+description = "Jede gewürfelte 1 misslingt, Auto-Erfolge müssen trotzdem würfeln (ENGINE-TODO)."
+modifiers = []
+
+[[advantages]]
+name = "Rechtschaffenheit"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Hält sich ans (aus seiner Sicht) herrschende Recht, auf Biegen und Brechen."
+modifiers = []
+
+[[advantages]]
+name = "Schüchtern"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Gehemmt unter Fremden; −2 auf Reden vor Publikum u.ä."
+modifiers = [{ value = -2, target = { type = "Tag", of = "publikum" } }]
+
+[[advantages]]
+name = "Primitiv"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Aufgewachsen unter TL 6 (5 CP/TL darunter); kann die dortigen Fertigkeiten."
+modifiers = []
+
+# GUESS: −2 Entfesseln und −3 normale Sitze als Tags, Rest narrativ.
+[[advantages]]
+name = "Riesig"
+kind = "Disadvantage"
+cp = 10
+level = 1
+description = "≥210 cm: fällt immer auf, keine normale Kleidung, −2 Entfesseln, Sitze nur mit −3."
+modifiers = [{ value = -2, target = { type = "Tag", of = "entfesseln" } }]
+
+[[advantages]]
+name = "Schlechte Ohren"
+kind = "Disadvantage"
+cp = 1
+level = 2
+description = "Malus auf Lausch-Wahrnehmung (1 CP für 2 Level, 4 für 4); Hörgerät gleicht aus."
+modifiers = [{ value = -2, target = { type = "Tag", of = "hören" } }]
+
+[[advantages]]
+name = "Schlechte Augen"
+kind = "Disadvantage"
+cp = 1
+level = 2
+description = "Malus auf Seh-Wahrnehmung; Brille gleicht aus (gefundene: 10%/5% Chance)."
+modifiers = [{ value = -2, target = { type = "Tag", of = "sehen" } }]
+
+[[advantages]]
+name = "Schlechte Nase"
+kind = "Disadvantage"
+cp = 1
+level = 2
+description = "Malus auf Riechen/Schmecken (1 CP für 2 Level, 4 für 4)."
+modifiers = [{ value = -2, target = { type = "Tag", of = "riechen" } }]
+
+# GUESS: BODY-Obergrenze 5 ist eine Chargen-Prüfung, kein Modifier.
+[[advantages]]
+name = "Schmächtig"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "BMI < 19; BODY darf nicht 6+ sein (Chargen-Regel), Kleidung sitzt nie."
+modifiers = []
+
+[[advantages]]
+name = "Tiefer Schlaf"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "Extrem schwer zu wecken (BODY/COOL gegen 15); danach −6, wird alle 10 Min. um 1 besser."
+modifiers = []
+
+# GUESS: Schmerz-Verdopplung wäre ENGINE-TODO; COOL-Wimmern-Wurf narrativ.
+[[advantages]]
+name = "Wehleidig"
+kind = "Disadvantage"
+cp = 10
+level = 1
+description = "Prellschaden zählt doppelt (ENGINE-TODO); COOL gegen 10+Schaden oder Jammern."
+modifiers = []
+
+[[advantages]]
+name = "Mangelnde Hörfilter"
+kind = "Disadvantage"
+cp = 5
+level = 1
+description = "−4 auf gesprochene Sprache verstehen unter erschwerten Umständen."
+modifiers = [{ value = -4, target = { type = "Tag", of = "sprache-verstehen" } }]

--- a/data/lifepath_classic.toml
+++ b/data/lifepath_classic.toml
@@ -1,0 +1,175 @@
+# CP2020 RAW lifepath (classic variant, Q29).
+#
+# BEST-EFFORT TRANSCRIPTION — the core manual PDF is a scan without text
+# layer, so these tables are reconstructed from the RB5 excerpts that quote
+# them verbatim (PARENTS' FATE, CHILDHOOD) plus knowledge of the RAW tables.
+# BITTE gegen CP2020 Core p.35ff reviewen und korrigieren — this file is
+# data, editing it changes the tool without touching code.
+
+background = ["family_ranking", "parents", "childhood", "siblings", "personality"]
+yearly = "life_event"
+
+[tables.family_ranking]
+title = "Familienhintergrund"
+entries = [
+    { min = 1, max = 1, text = "Konzern-Führungskraft" },
+    { min = 2, max = 2, text = "Konzern-Manager" },
+    { min = 3, max = 3, text = "Konzern-Techniker" },
+    { min = 4, max = 4, text = "Nomaden-Pack" },
+    { min = 5, max = 5, text = "Piraten-/Gang-Familie" },
+    { min = 6, max = 6, text = "Familie eines Verbrecherbosses" },
+    { min = 7, max = 7, text = "Arbeiterfamilie in der Combat Zone" },
+    { min = 8, max = 8, text = "Städtische Mittelschicht" },
+    { min = 9, max = 9, text = "Arm, aber ehrlich (Arbeiter)" },
+    { min = 10, max = 10, text = "Obdachlos / Street Trash" },
+]
+
+[tables.parents]
+title = "Eltern"
+entries = [
+    { min = 1, max = 6, text = "Beide Eltern leben" },
+    { min = 7, max = 10, text = "Etwas ist mit den Eltern passiert …", goto = "parents_fate" },
+]
+
+# verbatim from RB5 ("SOMETHING HAPPENED TO PARENTS")
+[tables.parents_fate]
+title = "Schicksal der Eltern"
+entries = [
+    { min = 1, max = 1, text = "Eltern wurden ermordet" },
+    { min = 2, max = 2, text = "Eltern starben im Krieg" },
+    { min = 3, max = 3, text = "Eltern starben bei einem Unfall" },
+    { min = 4, max = 4, text = "Eltern begingen Selbstmord" },
+    { min = 5, max = 5, text = "Du hast deine Eltern nie gekannt" },
+    { min = 6, max = 6, text = "Eltern verstecken sich, um dich zu schützen" },
+    { min = 7, max = 7, text = "Du wurdest bei Verwandten gelassen" },
+    { min = 8, max = 8, text = "Eltern gaben dich zur Adoption frei" },
+    { min = 9, max = 9, text = "Eltern wurden Fanatiker/Radikale" },
+    { min = 10, max = 10, text = "Eltern haben dich für Geld verkauft" },
+]
+
+# verbatim from RB5 ("CHILDHOOD ENVIRONMENT")
+[tables.childhood]
+title = "Kindheit"
+entries = [
+    { min = 1, max = 1, text = "Im Wohnheim einer Schule" },
+    { min = 2, max = 2, text = "Sicherer Konzern-Vorort/Arkologie" },
+    { min = 3, max = 3, text = "Konzern-Farm/Forschungseinrichtung" },
+    { min = 4, max = 4, text = "Normales Stadtleben" },
+    { min = 5, max = 5, text = "Auf der Straße, ohne Aufsicht" },
+    { min = 6, max = 6, text = "Kleines Dorf oder Kleinstadt" },
+    { min = 7, max = 7, text = "Kampfkunst-/religiöse Ausbildung" },
+    { min = 8, max = 8, text = "Gang/Piraten/Schmuggler" },
+    { min = 9, max = 10, text = "Ab 8 in Fabrik oder Laden gearbeitet" },
+]
+
+[tables.siblings]
+title = "Geschwister"
+entries = [
+    { min = 1, max = 2, text = "Ein Geschwister", goto = "sibling_feeling" },
+    { min = 3, max = 4, text = "Zwei Geschwister", goto = "sibling_feeling" },
+    { min = 5, max = 6, text = "Drei Geschwister", goto = "sibling_feeling" },
+    { min = 7, max = 7, text = "Vier Geschwister", goto = "sibling_feeling" },
+    { min = 8, max = 10, text = "Einzelkind" },
+]
+
+[tables.sibling_feeling]
+title = "Verhältnis zu den Geschwistern"
+entries = [
+    { min = 1, max = 2, text = "Sie bewundern dich" },
+    { min = 3, max = 4, text = "Ihr respektiert euch" },
+    { min = 5, max = 6, text = "Neutral bis distanziert" },
+    { min = 7, max = 8, text = "Sie verachten dich" },
+    { min = 9, max = 10, text = "Sie hassen dich (oder du sie)" },
+]
+
+[tables.personality]
+title = "Persönlichkeit"
+entries = [
+    { min = 1, max = 1, text = "Schüchtern und verschlossen" },
+    { min = 2, max = 2, text = "Rebellisch, asozial, gewalttätig" },
+    { min = 3, max = 3, text = "Arrogant, stolz, distanziert" },
+    { min = 4, max = 4, text = "Launisch, impulsiv, eigensinnig" },
+    { min = 5, max = 5, text = "Pingelig, nervös, penibel" },
+    { min = 6, max = 6, text = "Stabil, ernsthaft, verantwortungsvoll" },
+    { min = 7, max = 7, text = "Albern, verspielt, flatterhaft" },
+    { min = 8, max = 8, text = "Verschlagen und hinterhältig" },
+    { min = 9, max = 9, text = "Intellektuell und reserviert" },
+    { min = 10, max = 10, text = "Freundlich und offen" },
+]
+
+[tables.life_event]
+title = "Lebensereignis"
+entries = [
+    { min = 1, max = 4, text = "Großes Problem oder großer Gewinn", goto = "problem_or_win" },
+    { min = 5, max = 6, text = "Freund oder Feind", goto = "friend_enemy" },
+    { min = 7, max = 8, text = "Romanze", goto = "romance" },
+    { min = 9, max = 10, text = "Nichts Besonderes passiert" },
+]
+
+[tables.problem_or_win]
+title = "Problem oder Gewinn?"
+entries = [
+    { min = 1, max = 5, text = "Das Unglück schlägt zu …", goto = "disaster" },
+    { min = 6, max = 10, text = "Glück gehabt!", goto = "lucky" },
+]
+
+[tables.disaster]
+title = "Unglück"
+entries = [
+    { min = 1, max = 1, text = "Finanzieller Verlust oder Schulden (1W10 × 100 eb)" },
+    { min = 2, max = 2, text = "Gefängnis oder Gefangenschaft (1W10 Monate)" },
+    { min = 3, max = 3, text = "Krankheit oder Sucht" },
+    { min = 4, max = 4, text = "Verrat: erpresst, ein Geheimnis verraten oder hintergangen" },
+    { min = 5, max = 5, text = "Unfall (Narben, Krankenhaus, Gedächtnislücken …)" },
+    { min = 6, max = 6, text = "Partner oder Freund getötet" },
+    { min = 7, max = 7, text = "Falsche Anschuldigung" },
+    { min = 8, max = 8, text = "Vom Gesetz gejagt" },
+    { min = 9, max = 9, text = "Von Konzern oder Gang gejagt" },
+    { min = 10, max = 10, text = "Schwere Verletzung oder psychisches Trauma" },
+]
+
+[tables.lucky]
+title = "Glücksfall"
+entries = [
+    { min = 1, max = 1, text = "Mächtige Verbindung (Polizei, Konzern, Unterwelt)" },
+    { min = 2, max = 2, text = "Geldsegen (1W10 × 100 eb)" },
+    { min = 3, max = 3, text = "Großer Coup gelungen (2W10 × 100 eb)" },
+    { min = 4, max = 4, text = "Sensei gefunden (Kampfkunst +2 oder bestehende +1)" },
+    { min = 5, max = 5, text = "Lehrer gefunden (INT-Fertigkeit +1)" },
+    { min = 6, max = 6, text = "Einflussreiche Person schuldet dir einen Gefallen" },
+    { min = 7, max = 7, text = "Nomaden-/Flüchtlingsgruppe als Verbündete" },
+    { min = 8, max = 8, text = "Freund bei der Polizei/Miliz" },
+    { min = 9, max = 9, text = "Lokale Gang mag dich (Gefallen)" },
+    { min = 10, max = 10, text = "Kampflehrer gefunden (Kampffertigkeit +1)" },
+]
+
+[tables.friend_enemy]
+title = "Freund oder Feind"
+entries = [
+    { min = 1, max = 4, text = "Du gewinnst einen Freund" },
+    { min = 5, max = 10, text = "Du machst dir einen Feind …", goto = "enemy_who" },
+]
+
+[tables.enemy_who]
+title = "Der Feind ist …"
+entries = [
+    { min = 1, max = 1, text = "Ex-Freund" },
+    { min = 2, max = 2, text = "Ex-Geliebte(r)" },
+    { min = 3, max = 3, text = "Verwandte(r)" },
+    { min = 4, max = 4, text = "Feind aus der Kindheit" },
+    { min = 5, max = 5, text = "Jemand, der für dich arbeitet(e)" },
+    { min = 6, max = 6, text = "Jemand, für den du arbeitest(e)" },
+    { min = 7, max = 7, text = "Partner oder Kollege" },
+    { min = 8, max = 8, text = "Eine Gang" },
+    { min = 9, max = 9, text = "Ein Konzernmensch" },
+    { min = 10, max = 10, text = "Ein Beamter/Offizieller" },
+]
+
+[tables.romance]
+title = "Romanze"
+entries = [
+    { min = 1, max = 4, text = "Glückliche Liebesbeziehung" },
+    { min = 5, max = 5, text = "Tragische Liebe (Tod, Verschwinden, Verrat …)" },
+    { min = 6, max = 7, text = "Beziehung mit Hindernissen (verfeindete Familien, Rivale …)" },
+    { min = 8, max = 10, text = "Kurze Affären und heiße Dates" },
+]

--- a/data/lifepath_desaster.toml
+++ b/data/lifepath_desaster.toml
@@ -1,0 +1,172 @@
+# Desaster-Variante des Lifepath (Q29): startet als Kopie der klassischen
+# Tabellen — Ben interpretiert die Ergebnisse in die post-apokalyptische Welt
+# oder passt diese Datei direkt an (z.B. "Konzern" -> "Dom", "Polizei" ->
+# "Miliz der Werkstatt"). Struktur identisch mit lifepath_classic.toml.
+
+background = ["family_ranking", "parents", "childhood", "siblings", "personality"]
+yearly = "life_event"
+
+[tables.family_ranking]
+title = "Familienhintergrund"
+entries = [
+    { min = 1, max = 1, text = "Konzern-Führungskraft" },
+    { min = 2, max = 2, text = "Konzern-Manager" },
+    { min = 3, max = 3, text = "Konzern-Techniker" },
+    { min = 4, max = 4, text = "Nomaden-Pack" },
+    { min = 5, max = 5, text = "Piraten-/Gang-Familie" },
+    { min = 6, max = 6, text = "Familie eines Verbrecherbosses" },
+    { min = 7, max = 7, text = "Arbeiterfamilie in der Combat Zone" },
+    { min = 8, max = 8, text = "Städtische Mittelschicht" },
+    { min = 9, max = 9, text = "Arm, aber ehrlich (Arbeiter)" },
+    { min = 10, max = 10, text = "Obdachlos / Street Trash" },
+]
+
+[tables.parents]
+title = "Eltern"
+entries = [
+    { min = 1, max = 6, text = "Beide Eltern leben" },
+    { min = 7, max = 10, text = "Etwas ist mit den Eltern passiert …", goto = "parents_fate" },
+]
+
+# verbatim from RB5 ("SOMETHING HAPPENED TO PARENTS")
+[tables.parents_fate]
+title = "Schicksal der Eltern"
+entries = [
+    { min = 1, max = 1, text = "Eltern wurden ermordet" },
+    { min = 2, max = 2, text = "Eltern starben im Krieg" },
+    { min = 3, max = 3, text = "Eltern starben bei einem Unfall" },
+    { min = 4, max = 4, text = "Eltern begingen Selbstmord" },
+    { min = 5, max = 5, text = "Du hast deine Eltern nie gekannt" },
+    { min = 6, max = 6, text = "Eltern verstecken sich, um dich zu schützen" },
+    { min = 7, max = 7, text = "Du wurdest bei Verwandten gelassen" },
+    { min = 8, max = 8, text = "Eltern gaben dich zur Adoption frei" },
+    { min = 9, max = 9, text = "Eltern wurden Fanatiker/Radikale" },
+    { min = 10, max = 10, text = "Eltern haben dich für Geld verkauft" },
+]
+
+# verbatim from RB5 ("CHILDHOOD ENVIRONMENT")
+[tables.childhood]
+title = "Kindheit"
+entries = [
+    { min = 1, max = 1, text = "Im Wohnheim einer Schule" },
+    { min = 2, max = 2, text = "Sicherer Konzern-Vorort/Arkologie" },
+    { min = 3, max = 3, text = "Konzern-Farm/Forschungseinrichtung" },
+    { min = 4, max = 4, text = "Normales Stadtleben" },
+    { min = 5, max = 5, text = "Auf der Straße, ohne Aufsicht" },
+    { min = 6, max = 6, text = "Kleines Dorf oder Kleinstadt" },
+    { min = 7, max = 7, text = "Kampfkunst-/religiöse Ausbildung" },
+    { min = 8, max = 8, text = "Gang/Piraten/Schmuggler" },
+    { min = 9, max = 10, text = "Ab 8 in Fabrik oder Laden gearbeitet" },
+]
+
+[tables.siblings]
+title = "Geschwister"
+entries = [
+    { min = 1, max = 2, text = "Ein Geschwister", goto = "sibling_feeling" },
+    { min = 3, max = 4, text = "Zwei Geschwister", goto = "sibling_feeling" },
+    { min = 5, max = 6, text = "Drei Geschwister", goto = "sibling_feeling" },
+    { min = 7, max = 7, text = "Vier Geschwister", goto = "sibling_feeling" },
+    { min = 8, max = 10, text = "Einzelkind" },
+]
+
+[tables.sibling_feeling]
+title = "Verhältnis zu den Geschwistern"
+entries = [
+    { min = 1, max = 2, text = "Sie bewundern dich" },
+    { min = 3, max = 4, text = "Ihr respektiert euch" },
+    { min = 5, max = 6, text = "Neutral bis distanziert" },
+    { min = 7, max = 8, text = "Sie verachten dich" },
+    { min = 9, max = 10, text = "Sie hassen dich (oder du sie)" },
+]
+
+[tables.personality]
+title = "Persönlichkeit"
+entries = [
+    { min = 1, max = 1, text = "Schüchtern und verschlossen" },
+    { min = 2, max = 2, text = "Rebellisch, asozial, gewalttätig" },
+    { min = 3, max = 3, text = "Arrogant, stolz, distanziert" },
+    { min = 4, max = 4, text = "Launisch, impulsiv, eigensinnig" },
+    { min = 5, max = 5, text = "Pingelig, nervös, penibel" },
+    { min = 6, max = 6, text = "Stabil, ernsthaft, verantwortungsvoll" },
+    { min = 7, max = 7, text = "Albern, verspielt, flatterhaft" },
+    { min = 8, max = 8, text = "Verschlagen und hinterhältig" },
+    { min = 9, max = 9, text = "Intellektuell und reserviert" },
+    { min = 10, max = 10, text = "Freundlich und offen" },
+]
+
+[tables.life_event]
+title = "Lebensereignis"
+entries = [
+    { min = 1, max = 4, text = "Großes Problem oder großer Gewinn", goto = "problem_or_win" },
+    { min = 5, max = 6, text = "Freund oder Feind", goto = "friend_enemy" },
+    { min = 7, max = 8, text = "Romanze", goto = "romance" },
+    { min = 9, max = 10, text = "Nichts Besonderes passiert" },
+]
+
+[tables.problem_or_win]
+title = "Problem oder Gewinn?"
+entries = [
+    { min = 1, max = 5, text = "Das Unglück schlägt zu …", goto = "disaster" },
+    { min = 6, max = 10, text = "Glück gehabt!", goto = "lucky" },
+]
+
+[tables.disaster]
+title = "Unglück"
+entries = [
+    { min = 1, max = 1, text = "Finanzieller Verlust oder Schulden (1W10 × 100 eb)" },
+    { min = 2, max = 2, text = "Gefängnis oder Gefangenschaft (1W10 Monate)" },
+    { min = 3, max = 3, text = "Krankheit oder Sucht" },
+    { min = 4, max = 4, text = "Verrat: erpresst, ein Geheimnis verraten oder hintergangen" },
+    { min = 5, max = 5, text = "Unfall (Narben, Krankenhaus, Gedächtnislücken …)" },
+    { min = 6, max = 6, text = "Partner oder Freund getötet" },
+    { min = 7, max = 7, text = "Falsche Anschuldigung" },
+    { min = 8, max = 8, text = "Vom Gesetz gejagt" },
+    { min = 9, max = 9, text = "Von Konzern oder Gang gejagt" },
+    { min = 10, max = 10, text = "Schwere Verletzung oder psychisches Trauma" },
+]
+
+[tables.lucky]
+title = "Glücksfall"
+entries = [
+    { min = 1, max = 1, text = "Mächtige Verbindung (Polizei, Konzern, Unterwelt)" },
+    { min = 2, max = 2, text = "Geldsegen (1W10 × 100 eb)" },
+    { min = 3, max = 3, text = "Großer Coup gelungen (2W10 × 100 eb)" },
+    { min = 4, max = 4, text = "Sensei gefunden (Kampfkunst +2 oder bestehende +1)" },
+    { min = 5, max = 5, text = "Lehrer gefunden (INT-Fertigkeit +1)" },
+    { min = 6, max = 6, text = "Einflussreiche Person schuldet dir einen Gefallen" },
+    { min = 7, max = 7, text = "Nomaden-/Flüchtlingsgruppe als Verbündete" },
+    { min = 8, max = 8, text = "Freund bei der Polizei/Miliz" },
+    { min = 9, max = 9, text = "Lokale Gang mag dich (Gefallen)" },
+    { min = 10, max = 10, text = "Kampflehrer gefunden (Kampffertigkeit +1)" },
+]
+
+[tables.friend_enemy]
+title = "Freund oder Feind"
+entries = [
+    { min = 1, max = 4, text = "Du gewinnst einen Freund" },
+    { min = 5, max = 10, text = "Du machst dir einen Feind …", goto = "enemy_who" },
+]
+
+[tables.enemy_who]
+title = "Der Feind ist …"
+entries = [
+    { min = 1, max = 1, text = "Ex-Freund" },
+    { min = 2, max = 2, text = "Ex-Geliebte(r)" },
+    { min = 3, max = 3, text = "Verwandte(r)" },
+    { min = 4, max = 4, text = "Feind aus der Kindheit" },
+    { min = 5, max = 5, text = "Jemand, der für dich arbeitet(e)" },
+    { min = 6, max = 6, text = "Jemand, für den du arbeitest(e)" },
+    { min = 7, max = 7, text = "Partner oder Kollege" },
+    { min = 8, max = 8, text = "Eine Gang" },
+    { min = 9, max = 9, text = "Ein Konzernmensch" },
+    { min = 10, max = 10, text = "Ein Beamter/Offizieller" },
+]
+
+[tables.romance]
+title = "Romanze"
+entries = [
+    { min = 1, max = 4, text = "Glückliche Liebesbeziehung" },
+    { min = 5, max = 5, text = "Tragische Liebe (Tod, Verschwinden, Verrat …)" },
+    { min = 6, max = 7, text = "Beziehung mit Hindernissen (verfeindete Familien, Rivale …)" },
+    { min = 8, max = 10, text = "Kurze Affären und heiße Dates" },
+]

--- a/docs/rules/hausregeln.wiki
+++ b/docs/rules/hausregeln.wiki
@@ -96,7 +96,7 @@ Modifikationen:
 *+2 für jede Kugel die pro Runde abgefeuert wird
 Um also eine AK (5D6 Schaden) in einer Entfernung von 200 Meterrn zu hören:
 
-(5*(6/2)) * 3 = 45 (-2*4) = 38 Bonus
+(5*(6/2)) * 3 = 45 (-2*4) = 37 Bonus
 
 Aus 1200 Metern
 

--- a/src/advantages.rs
+++ b/src/advantages.rs
@@ -102,6 +102,21 @@ impl fmt::Display for Advantage {
     }
 }
 
+#[derive(Deserialize)]
+struct AdvantageCatalog {
+    advantages: Vec<Advantage>,
+}
+
+/// The trait catalog from the wiki (docs/rules/VorUndNachteile.wiki),
+/// loaded from data/advantages.toml. Mechanical effects are best guesses
+/// marked with GUESS comments in the data file (Q30) — leveled traits are
+/// encoded at their smallest level; clone with `with_level` and scale.
+pub fn advantage_catalog() -> Vec<Advantage> {
+    let catalog: AdvantageCatalog = toml::from_str(include_str!("../data/advantages.toml"))
+        .expect("embedded advantage catalog must parse");
+    catalog.advantages
+}
+
 /// Validates the chargen budget rule: up to 30 CP of traits in total, or
 /// exactly ONE trait bigger than 30 plus at most 5 CP of others.
 pub fn validate_budget(advantages: &[Advantage]) -> Result<(), String> {
@@ -187,6 +202,33 @@ mod tests {
     #[should_panic(expected = "cp must not be negative")]
     fn test_negative_cp_panics() {
         plain("Broken", -10);
+    }
+
+    #[test]
+    fn test_catalog_parses_and_covers_the_wiki_list() {
+        let catalog = advantage_catalog();
+        assert!(
+            catalog.len() >= 60,
+            "expected the full wiki list, got {}",
+            catalog.len()
+        );
+        // spot checks: one mechanical advantage, one disadvantage, one narrative
+        let fast_healing = catalog
+            .iter()
+            .find(|advantage| advantage.name == "Schnelle Heilung")
+            .unwrap();
+        assert_eq!(fast_healing.modifiers.len(), 1);
+        let slow_healing = catalog
+            .iter()
+            .find(|advantage| advantage.name == "Langsame Heilung")
+            .unwrap();
+        assert_eq!(slow_healing.kind, AdvantageKind::Disadvantage);
+        assert_eq!(slow_healing.modifiers[0].value, -1);
+        let honest = catalog
+            .iter()
+            .find(|advantage| advantage.name == "Ehrlich")
+            .unwrap();
+        assert!(honest.modifiers.is_empty());
     }
 
     #[test]

--- a/src/armor.rs
+++ b/src/armor.rs
@@ -166,6 +166,9 @@ impl Armor {
                 DamageType::Blunt => self.hit_blunt(zone, &mut remaining_damage),
                 DamageType::HollowPoint => self.hit_hollow_point(zone, &mut remaining_damage),
                 DamageType::Slashing => self.hit_slashing(zone, &mut remaining_damage),
+                // fire licks around armor no better than a blunt impact:
+                // full protection value, no modifications
+                DamageType::Fire => self.hit_blunt(zone, &mut remaining_damage),
             };
             DamageResult {
                 remaining_damage,

--- a/src/character.rs
+++ b/src/character.rs
@@ -3,6 +3,10 @@ use crate::advantages::{
 };
 use crate::dice::{skill_check, CheckResult, DieRoller, Difficulty};
 use crate::health::WoundState;
+use crate::melee::{
+    dam_for_body, MartialArtsAction, MartialArtsStyle, MeleeClass, MELEE_GENERAL_CAP,
+    SKILL_MELEE_GENERAL,
+};
 use crate::{armor::HitZone, Armor};
 use crate::{inventory::Inventory, DamageType};
 use serde::{Deserialize, Serialize};
@@ -353,6 +357,127 @@ Character {{ \n\
         }
     }
 
+    /// The hand-to-hand damage modifier (DAM, "DAMAGE MOD" on the sheet),
+    /// based on the sheet BODY plus advantage modifiers.
+    pub fn dam(&self) -> i32 {
+        dam_for_body(
+            self.attributes.get(&Attribute::Body).unwrap().actual
+                + self.modifier_for_attribute(Attribute::Body),
+        )
+    }
+
+    fn skill_level(&self, name: &str) -> Option<i32> {
+        self.skills
+            .iter()
+            .find(|skill| skill.name == name)
+            .map(|skill| skill.level)
+    }
+
+    /// The melee level used with a weapon class: the specialization if the
+    /// character has it, otherwise the shared general skill (capped at 3).
+    pub fn melee_level(&self, class: MeleeClass) -> i32 {
+        self.skill_level(class.skill_name()).unwrap_or_else(|| {
+            self.skill_level(SKILL_MELEE_GENERAL)
+                .unwrap_or(0)
+                .min(MELEE_GENERAL_CAP)
+        })
+    }
+
+    /// Rolls a melee attack with a weapon class. Unfamiliar weapons within
+    /// the class raise the difficulty by 3 (Q25).
+    pub fn check_melee(
+        &mut self,
+        class: MeleeClass,
+        familiar: bool,
+        luck: i32,
+        difficulty: Difficulty,
+        roller: &mut dyn DieRoller,
+    ) -> Result<CheckResult, String> {
+        let target = difficulty.target() + if familiar { 0 } else { 3 };
+        let (attribute_value, level) = (
+            self.effective_attribute(Attribute::Reflexes),
+            self.melee_level(class),
+        );
+        self.spend_luck(luck)?;
+        let malus = std::mem::take(&mut self.pending_roll_malus);
+        Ok(skill_check(
+            attribute_value - malus,
+            level,
+            luck,
+            Difficulty::Custom(target),
+            roller,
+        ))
+    }
+
+    /// Rolls a dodge: always uses the general melee level (capped at 3),
+    /// specializations don't help here (Q24).
+    pub fn check_dodge(
+        &mut self,
+        luck: i32,
+        difficulty: Difficulty,
+        roller: &mut dyn DieRoller,
+    ) -> Result<CheckResult, String> {
+        let (attribute_value, level) = (
+            self.effective_attribute(Attribute::Reflexes),
+            self.skill_level(SKILL_MELEE_GENERAL)
+                .unwrap_or(0)
+                .min(MELEE_GENERAL_CAP),
+        );
+        self.spend_luck(luck)?;
+        let malus = std::mem::take(&mut self.pending_roll_malus);
+        Ok(skill_check(
+            attribute_value - malus,
+            level,
+            luck,
+            difficulty,
+            roller,
+        ))
+    }
+
+    /// Rolls a martial arts action: REF + style skill + the style's
+    /// key-attack bonus. Errors if the character doesn't know the style.
+    pub fn check_martial_arts(
+        &mut self,
+        style: MartialArtsStyle,
+        action: MartialArtsAction,
+        luck: i32,
+        difficulty: Difficulty,
+        roller: &mut dyn DieRoller,
+    ) -> Result<CheckResult, String> {
+        let level = self.skill_level(style.skill_name()).ok_or_else(|| {
+            format!(
+                "Character '{}' has no skill named '{}'",
+                self.name,
+                style.skill_name()
+            )
+        })?;
+        let attribute_value = self.effective_attribute(Attribute::Reflexes);
+        self.spend_luck(luck)?;
+        let malus = std::mem::take(&mut self.pending_roll_malus);
+        Ok(skill_check(
+            attribute_value + style.key_attack_bonus(action) - malus,
+            level,
+            luck,
+            difficulty,
+            roller,
+        ))
+    }
+
+    /// Rolls the damage of a martial arts action: base dice + DAM (where the
+    /// body's mass matters) + style skill level 1:1 (Q26).
+    /// `None` for actions that don't deal damage. Minimum 0.
+    pub fn martial_arts_damage(
+        &self,
+        style: MartialArtsStyle,
+        action: MartialArtsAction,
+        roller: &mut dyn DieRoller,
+    ) -> Option<i32> {
+        let base = action.base_damage()?;
+        let level = self.skill_level(style.skill_name()).unwrap_or(0);
+        let dam = if action.applies_dam() { self.dam() } else { 0 };
+        Some((base.roll(roller) + dam + level).max(0))
+    }
+
     /// The KO check after taking damage: BODY against 10, modified by the
     /// wound category's Stun malus (Light −0, Serious −1, Critical −2,
     /// Mortal 0 −3, one more per Mortal step).
@@ -370,6 +495,22 @@ Character {{ \n\
             + self.modifier_for_attribute(Attribute::Body)
             - self.wound_state().ko_malus();
         skill_check(body, 0, 0, Difficulty::Custom(10), roller)
+    }
+
+    /// The crippling check for one critical-or-worse injury, rolled directly
+    /// after the fight (Q22): 5% chance without proper medical care, 0.5%
+    /// with; Schnelle Heilung (healing-rate tag > 0) lowers that to 1% /
+    /// 0.1%. Returns true when the body part is crippled — what that means
+    /// concretely is the GM's call, the tool only reports it.
+    pub fn crippling_check(&self, medical_care: bool, roller: &mut dyn DieRoller) -> bool {
+        let fast_healer = self.modifier_for_tag(TAG_HEALING_RATE) > 0;
+        let per_mille = match (medical_care, fast_healer) {
+            (false, false) => 50,
+            (true, false) => 5,
+            (false, true) => 10,
+            (true, true) => 1,
+        };
+        crate::dice::roll_per_mille(roller) < per_mille
     }
 
     /// The morning-after complication check: BODY against 10 + current damage.
@@ -1339,6 +1480,179 @@ mod tests {
         let outcome = character.hit(3, HitZone::Chest, DamageType::Blunt, true, &mut roller);
         assert!(!outcome.ko_check_required);
         assert_eq!(character.pending_roll_malus, 3);
+    }
+
+    #[test]
+    fn test_melee_specialization_continues_the_scale() {
+        use crate::melee::{MeleeClass, SKILL_MELEE_GENERAL};
+        let mut character = unencumbered_shooter(); // REF 8
+        character.skills.push(Skill::new(
+            SKILL_MELEE_GENERAL.to_string(),
+            Attribute::Reflexes,
+            3,
+            1,
+        ));
+        character.skills.push(Skill::new(
+            MeleeClass::Short.skill_name().to_string(),
+            Attribute::Reflexes,
+            4,
+            1,
+        ));
+        // Ben's Q23 example: 1d10+4 with short weapons, 1d10+3 with medium
+        assert_eq!(character.melee_level(MeleeClass::Short), 4);
+        assert_eq!(character.melee_level(MeleeClass::Medium), 3);
+        assert_eq!(character.melee_level(MeleeClass::Long), 3);
+
+        let mut roller = crate::dice::SequenceRoller::new(vec![5]);
+        let result = character
+            .check_melee(MeleeClass::Short, true, 0, Difficulty::Hard, &mut roller)
+            .unwrap();
+        // REF 8 + Kurz 4 + die 5 = 17
+        assert_eq!(result.total, 17);
+    }
+
+    #[test]
+    fn test_melee_general_is_capped_at_three() {
+        use crate::melee::{MeleeClass, SKILL_MELEE_GENERAL};
+        let mut character = unencumbered_shooter();
+        // an (invalid) general level above the cap doesn't leak into rolls
+        character.skills.push(Skill::new(
+            SKILL_MELEE_GENERAL.to_string(),
+            Attribute::Reflexes,
+            5,
+            1,
+        ));
+        assert_eq!(character.melee_level(MeleeClass::Medium), 3);
+    }
+
+    #[test]
+    fn test_unfamiliar_weapon_raises_difficulty() {
+        use crate::melee::MeleeClass;
+        let mut character = unencumbered_shooter();
+        let mut roller = crate::dice::SequenceRoller::new(vec![5]);
+        let result = character
+            .check_melee(MeleeClass::Short, false, 0, Difficulty::Normal, &mut roller)
+            .unwrap();
+        assert_eq!(result.target, 18);
+    }
+
+    #[test]
+    fn test_dodge_ignores_specialization() {
+        use crate::melee::{MeleeClass, SKILL_MELEE_GENERAL};
+        let mut character = unencumbered_shooter();
+        character.skills.push(Skill::new(
+            SKILL_MELEE_GENERAL.to_string(),
+            Attribute::Reflexes,
+            3,
+            1,
+        ));
+        character.skills.push(Skill::new(
+            MeleeClass::Short.skill_name().to_string(),
+            Attribute::Reflexes,
+            6,
+            1,
+        ));
+        let mut roller = crate::dice::SequenceRoller::new(vec![5]);
+        let result = character
+            .check_dodge(0, Difficulty::Hard, &mut roller)
+            .unwrap();
+        // REF 8 + general 3 (NOT Kurz 6) + die 5 = 16
+        assert_eq!(result.total, 16);
+    }
+
+    #[test]
+    fn test_martial_arts_check_and_damage() {
+        use crate::melee::{MartialArtsAction, MartialArtsStyle};
+        let mut character = unencumbered_shooter(); // REF 8, BODY 10 -> DAM +2
+        character.skills.push(Skill::new(
+            MartialArtsStyle::Boxen.skill_name().to_string(),
+            Attribute::Reflexes,
+            4,
+            1,
+        ));
+
+        // Boxen Punch: REF 8 + skill 4 + key attack +3 + die 4 = 19
+        let mut roller = crate::dice::SequenceRoller::new(vec![4]);
+        let result = character
+            .check_martial_arts(
+                MartialArtsStyle::Boxen,
+                MartialArtsAction::Punch,
+                0,
+                Difficulty::Hard,
+                &mut roller,
+            )
+            .unwrap();
+        assert_eq!(result.total, 19);
+
+        // Punch damage: 1d3 (2) + DAM 2 + skill 4 = 8
+        let mut roller = crate::dice::SequenceRoller::new(vec![2]);
+        let damage = character
+            .martial_arts_damage(
+                MartialArtsStyle::Boxen,
+                MartialArtsAction::Punch,
+                &mut roller,
+            )
+            .unwrap();
+        assert_eq!(damage, 8);
+
+        // Sweep deals no direct damage
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        assert!(character
+            .martial_arts_damage(
+                MartialArtsStyle::Boxen,
+                MartialArtsAction::Sweep,
+                &mut roller
+            )
+            .is_none());
+
+        // unknown style errors
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        let error = character
+            .check_martial_arts(
+                MartialArtsStyle::Ringen,
+                MartialArtsAction::Grapple,
+                0,
+                Difficulty::Normal,
+                &mut roller,
+            )
+            .unwrap_err();
+        assert!(error.contains("Kampfkunst Ringen"), "{}", error);
+    }
+
+    #[test]
+    fn test_crippling_check_percentages() {
+        let character = unencumbered_shooter();
+        // no care: 5% -> 049 cripples, 050 doesn't
+        let mut roller = crate::dice::SequenceRoller::new(vec![10, 4, 9]);
+        assert!(character.crippling_check(false, &mut roller));
+        let mut roller = crate::dice::SequenceRoller::new(vec![10, 5, 10]);
+        assert!(!character.crippling_check(false, &mut roller));
+        // with care: 0.5% -> 004 cripples, 005 doesn't
+        let mut roller = crate::dice::SequenceRoller::new(vec![10, 10, 4]);
+        assert!(character.crippling_check(true, &mut roller));
+        let mut roller = crate::dice::SequenceRoller::new(vec![10, 10, 5]);
+        assert!(!character.crippling_check(true, &mut roller));
+
+        // Schnelle Heilung: 1% / 0.1%
+        use crate::advantages::{Advantage, AdvantageKind, ModifierTarget, TAG_HEALING_RATE};
+        let mut character = unencumbered_shooter();
+        character.advantages.push(
+            Advantage::new(
+                "Schnelle Heilung".to_string(),
+                AdvantageKind::Advantage,
+                5,
+                String::new(),
+            )
+            .with_modifier(ModifierTarget::Tag(TAG_HEALING_RATE.to_string()), 1),
+        );
+        let mut roller = crate::dice::SequenceRoller::new(vec![10, 10, 9]);
+        assert!(character.crippling_check(false, &mut roller));
+        let mut roller = crate::dice::SequenceRoller::new(vec![10, 1, 10]);
+        assert!(!character.crippling_check(false, &mut roller));
+        let mut roller = crate::dice::SequenceRoller::new(vec![10, 10, 10]);
+        assert!(character.crippling_check(true, &mut roller)); // 000 < 1
+        let mut roller = crate::dice::SequenceRoller::new(vec![10, 10, 1]);
+        assert!(!character.crippling_check(true, &mut roller));
     }
 
     #[test]

--- a/src/character.rs
+++ b/src/character.rs
@@ -478,6 +478,56 @@ Character {{ \n\
         Some((base.roll(roller) + dam + level).max(0))
     }
 
+    /// Rolls a ranged attack with a weapon: like [`Character::check_skill`]
+    /// plus the weapon accuracy (WA) and +1 if the weapon has a scope.
+    /// Autofire/burst modifiers are the caller's business
+    /// (see `weapons::autofire_attack_modifier` / `BURST_ATTACK_BONUS`).
+    pub fn check_ranged_attack(
+        &mut self,
+        weapon: &crate::weapons::Weapon,
+        skill_name: &str,
+        luck: i32,
+        difficulty: Difficulty,
+        roller: &mut dyn DieRoller,
+    ) -> Result<CheckResult, String> {
+        let skill = self
+            .skills
+            .iter()
+            .find(|skill| skill.name == skill_name)
+            .ok_or_else(|| {
+                format!(
+                    "Character '{}' has no skill named '{}'",
+                    self.name, skill_name
+                )
+            })?;
+        let (attribute_value, skill_level) = (self.effective_attribute(skill.base), skill.level);
+        let advantage_bonus = self.modifier_for_skill(skill_name);
+        let weapon_bonus = weapon.weapon_accuracy + if weapon.scope { 1 } else { 0 };
+        self.spend_luck(luck)?;
+        let malus = std::mem::take(&mut self.pending_roll_malus);
+        Ok(skill_check(
+            attribute_value + advantage_bonus + weapon_bonus - malus,
+            skill_level,
+            luck,
+            difficulty,
+            roller,
+        ))
+    }
+
+    /// Rolls a weapon's damage. Melee weapons add the wielder's DAM.
+    pub fn weapon_damage(
+        &self,
+        weapon: &crate::weapons::Weapon,
+        roller: &mut dyn DieRoller,
+    ) -> i32 {
+        let dam = if weapon.category.melee_class().is_some() {
+            self.dam()
+        } else {
+            0
+        };
+        (weapon.damage.roll(roller) + dam).max(0)
+    }
+
     /// The KO check after taking damage: BODY against 10, modified by the
     /// wound category's Stun malus (Light −0, Serious −1, Critical −2,
     /// Mortal 0 −3, one more per Mortal step).
@@ -653,7 +703,9 @@ Character {{ \n\
             }
         }
 
-        let mut outcome = self.resolve_damage(remaining_damage, soft_absorbed, zone);
+        // fire damage ignores the ">8 damage" crippling rule
+        let can_cripple = damage_type != DamageType::Fire;
+        let mut outcome = self.resolve_damage(remaining_damage, soft_absorbed, zone, can_cripple);
         outcome.through_and_through = through_and_through;
         outcome
     }
@@ -661,7 +713,7 @@ Character {{ \n\
     /// This ignores all armor and applies damage directly.
     /// It will subtract the BTM first.
     pub fn take_damage(&mut self, damage: i32, zone: HitZone) -> HitOutcome {
-        self.resolve_damage(damage, 0, zone)
+        self.resolve_damage(damage, 0, zone, true)
     }
 
     /// Core damage resolution after armor: BTM conversion, bruise scale,
@@ -675,7 +727,13 @@ Character {{ \n\
     ///   that amount on the character's next roll.
     /// - The crippling check (8+ zone damage after BTM) uses the UNDOUBLED
     ///   value; head doubling is applied afterwards.
-    fn resolve_damage(&mut self, incoming: i32, armor_bruise: i32, zone: HitZone) -> HitOutcome {
+    fn resolve_damage(
+        &mut self,
+        incoming: i32,
+        armor_bruise: i32,
+        zone: HitZone,
+        can_cripple: bool,
+    ) -> HitOutcome {
         let mut real_damage = incoming.max(0);
         let mut bruise = armor_bruise;
 
@@ -698,7 +756,8 @@ Character {{ \n\
         }
 
         // Crippling check against the unmodified zone damage, doubling after.
-        let crippled = real_damage >= 8;
+        // Fire never cripples (can_cripple = false, Q: Hausregeln Niederbrennen).
+        let crippled = can_cripple && real_damage >= 8;
         let mut applied_damage = real_damage;
         if zone == HitZone::Head {
             applied_damage *= 2;
@@ -1653,6 +1712,66 @@ mod tests {
         assert!(character.crippling_check(true, &mut roller)); // 000 < 1
         let mut roller = crate::dice::SequenceRoller::new(vec![10, 10, 1]);
         assert!(!character.crippling_check(true, &mut roller));
+    }
+
+    #[test]
+    fn test_ranged_attack_applies_weapon_accuracy_and_scope() {
+        use crate::weapons::{Weapon, WeaponCategory};
+        let mut character = unencumbered_shooter(); // REF 8, Pistole 4
+        let catalog = Weapon::catalog();
+        let mut smg = catalog
+            .iter()
+            .find(|weapon| weapon.category == WeaponCategory::Smg)
+            .unwrap()
+            .clone();
+        // Uzi WA +1: REF 8 + Pistole 4 + WA 1 + die 4 = 17
+        let mut roller = crate::dice::SequenceRoller::new(vec![4]);
+        let result = character
+            .check_ranged_attack(&smg, "Pistole", 0, Difficulty::Hard, &mut roller)
+            .unwrap();
+        assert_eq!(result.total, 17);
+
+        // scope adds +1
+        smg.scope = true;
+        let mut roller = crate::dice::SequenceRoller::new(vec![4]);
+        let result = character
+            .check_ranged_attack(&smg, "Pistole", 0, Difficulty::Hard, &mut roller)
+            .unwrap();
+        assert_eq!(result.total, 18);
+    }
+
+    #[test]
+    fn test_melee_weapon_damage_adds_dam() {
+        use crate::weapons::{Weapon, WeaponCategory};
+        let character = unencumbered_shooter(); // BODY 10 -> DAM +2
+        let catalog = Weapon::catalog();
+        let knife = catalog
+            .iter()
+            .find(|weapon| weapon.category == WeaponCategory::Knife)
+            .unwrap();
+        // Combat Knife 1d6+3: die 4 + 3 + DAM 2 = 9
+        let mut roller = crate::dice::SequenceRoller::new(vec![4]);
+        assert_eq!(character.weapon_damage(knife, &mut roller), 9);
+
+        // ranged weapons don't add DAM
+        let ak = catalog
+            .iter()
+            .find(|weapon| weapon.category == WeaponCategory::Rifle)
+            .unwrap();
+        let mut roller = crate::dice::SequenceRoller::new(vec![3, 3, 3, 3, 3]);
+        assert_eq!(character.weapon_damage(ak, &mut roller), 15);
+    }
+
+    #[test]
+    fn test_fire_damage_never_cripples() {
+        let mut character = unencumbered_shooter(); // BTM 4
+        let mut roller = crate::dice::SequenceRoller::new(vec![]);
+        // 20 fire damage, no armor: 20 - 4 BTM = 16 zone damage -> would
+        // cripple/kill for any other type, but fire ignores the 8+ rule
+        let outcome = character.hit(20, HitZone::Chest, DamageType::Fire, false, &mut roller);
+        assert_eq!(character.damage_notes, "");
+        assert!(outcome.real_damage >= 16);
+        assert_ne!(character.current_damage, 100);
     }
 
     #[test]

--- a/src/chargen.rs
+++ b/src/chargen.rs
@@ -1,0 +1,544 @@
+use crate::advantages::{validate_budget, AdvantageKind};
+use crate::character::{Attribute, Character, Skill};
+use crate::dice::DieRoller;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// Which lifepath table set to use (Q29). The Desaster variant starts as a
+/// copy of the classic tables and is meant to be edited over time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifepathVariant {
+    Classic,
+    Desaster,
+}
+
+/// Attribute rules at creation: 60 points over the 9 attributes,
+/// each between 2 and 9 (10 is not allowed at creation), INT and REF ≥ 5.
+pub const ATTRIBUTE_POINTS: i32 = 60;
+
+pub fn validate_attributes(character: &Character) -> Result<(), Vec<String>> {
+    let mut errors = Vec::new();
+    let mut total = 0;
+    for (attribute, value) in character.attributes.iter() {
+        total += value.base;
+        if !(2..=9).contains(&value.base) {
+            errors.push(format!(
+                "{}: base value {} outside 2..=9 (10 is not allowed at creation)",
+                attribute, value.base
+            ));
+        }
+    }
+    for required in [Attribute::Intelligence, Attribute::Reflexes] {
+        if character.attributes.get(&required).unwrap().base < 5 {
+            errors.push(format!("{} must be at least 5", required));
+        }
+    }
+    if total != ATTRIBUTE_POINTS {
+        errors.push(format!(
+            "attribute points must total {}, got {}",
+            ATTRIBUTE_POINTS, total
+        ));
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+/// Extra skill points from age (docs/rules/Alterspunkte.wiki).
+/// Beyond the table's end (32) the +3 pattern continues; note that
+/// characters older than 28 hit the still-unwritten aging rules (#22).
+pub fn age_points(age: i32) -> i32 {
+    match age {
+        ..=15 => 0,
+        16..=24 => age - 15,
+        25 => 11,
+        26 => 13,
+        27 => 15,
+        28 => 17,
+        29 => 20,
+        30 => 23,
+        31 => 26,
+        32 => 29,
+        _ => 29 + 3 * (age - 32),
+    }
+}
+
+/// The skill point pool at creation: INT + REF + 40 + age points.
+pub fn skill_point_pool(character: &Character) -> i32 {
+    character
+        .attributes
+        .get(&Attribute::Intelligence)
+        .unwrap()
+        .base
+        + character.attributes.get(&Attribute::Reflexes).unwrap().base
+        + 40
+        + age_points(character.age)
+}
+
+/// Cost of a skill at creation: every level costs its number
+/// (level 3 = 1 + 2 + 3 = 6 points).
+pub fn skill_cost(level: i32) -> i32 {
+    level * (level + 1) / 2
+}
+
+/// Validates the high-skill caps: one skill at 8, one at 7, two at 6 —
+/// tradeable 1:2 downward (no 8 allows three 7s, etc.).
+pub fn validate_skill_caps(skills: &[Skill]) -> Result<(), String> {
+    let count_at = |level: i32| skills.iter().filter(|skill| skill.level == level).count() as i32;
+    if let Some(skill) = skills.iter().find(|skill| skill.level > 8) {
+        return Err(format!(
+            "'{}' has level {}: above 8 is not allowed at creation",
+            skill.name, skill.level
+        ));
+    }
+    let mut slots_8 = 1;
+    let used_8 = count_at(8);
+    if used_8 > slots_8 {
+        return Err(format!("only one skill at 8 allowed, found {}", used_8));
+    }
+    slots_8 -= used_8;
+    let mut slots_7 = 1 + 2 * slots_8;
+    let used_7 = count_at(7);
+    if used_7 > slots_7 {
+        return Err(format!(
+            "too many skills at 7: {} (allowed {})",
+            used_7, slots_7
+        ));
+    }
+    slots_7 -= used_7;
+    let slots_6 = 2 + 2 * slots_7;
+    let used_6 = count_at(6);
+    if used_6 > slots_6 {
+        return Err(format!(
+            "too many skills at 6: {} (allowed {})",
+            used_6, slots_6
+        ));
+    }
+    Ok(())
+}
+
+/// Validates the full skill/advantage budget: skill costs plus advantage CP
+/// (1 CP = 1 skill point; disadvantages grant points) against the pool.
+pub fn validate_skill_budget(character: &Character) -> Result<i32, String> {
+    validate_budget(&character.advantages)?;
+    let pool = skill_point_pool(character);
+    let skill_costs: i32 = character
+        .skills
+        .iter()
+        .map(|skill| skill_cost(skill.level))
+        .sum();
+    let advantage_costs: i32 = character
+        .advantages
+        .iter()
+        .map(|advantage| match advantage.kind {
+            AdvantageKind::Advantage => advantage.cp,
+            AdvantageKind::Disadvantage => -advantage.cp,
+        })
+        .sum();
+    let spent = skill_costs + advantage_costs;
+    if spent > pool {
+        Err(format!(
+            "skill budget exceeded: {} spent (skills {} + advantages {}), pool is {}",
+            spent, skill_costs, advantage_costs, pool
+        ))
+    } else {
+        Ok(pool - spent)
+    }
+}
+
+/// Starting money: the levels of three profession-defining skills
+/// (player-chosen, GM veto) × 350 eb; the Reich advantage doubles the
+/// factor per level (tag `reich`).
+pub fn starting_money(character: &Character, profession_skills: &[&str; 3]) -> Result<i32, String> {
+    let mut sum = 0;
+    for name in profession_skills {
+        let skill = character
+            .skills
+            .iter()
+            .find(|skill| &skill.name == name)
+            .ok_or_else(|| format!("profession skill '{}' not found on the character", name))?;
+        sum += skill.level;
+    }
+    let factor = 350 << character.modifier_for_tag("reich").max(0);
+    Ok(sum * factor)
+}
+
+/// Runs all creation validations at once and returns the collected errors.
+pub fn validate_character(character: &Character) -> Result<(), Vec<String>> {
+    let mut errors = Vec::new();
+    if let Err(mut attribute_errors) = validate_attributes(character) {
+        errors.append(&mut attribute_errors);
+    }
+    if let Err(error) = validate_skill_caps(&character.skills) {
+        errors.push(error);
+    }
+    if let Err(error) = validate_skill_budget(character) {
+        errors.push(error);
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+// --------------------------------------------------------------------------
+// Lifepath
+// --------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct LifepathData {
+    /// Tables rolled once for the background, in this order.
+    background: Vec<String>,
+    /// Entry table for each year above 15.
+    yearly: String,
+    tables: BTreeMap<String, LifepathTable>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LifepathTable {
+    title: String,
+    entries: Vec<LifepathTableEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LifepathTableEntry {
+    min: i32,
+    max: i32,
+    text: String,
+    /// Follow-up table to roll on afterwards.
+    goto: Option<String>,
+}
+
+/// One resolved lifepath line: which table said what.
+#[derive(Debug, PartialEq, Eq)]
+pub struct LifepathEvent {
+    /// Age the event happened at; 0 for background rolls.
+    pub age: i32,
+    pub table: String,
+    pub text: String,
+}
+
+const LIFEPATH_CLASSIC: &str = include_str!("../data/lifepath_classic.toml");
+const LIFEPATH_DESASTER: &str = include_str!("../data/lifepath_desaster.toml");
+
+fn lifepath_data(variant: LifepathVariant) -> LifepathData {
+    let raw = match variant {
+        LifepathVariant::Classic => LIFEPATH_CLASSIC,
+        LifepathVariant::Desaster => LIFEPATH_DESASTER,
+    };
+    toml::from_str(raw).expect("embedded lifepath data must parse")
+}
+
+fn resolve_table(
+    data: &LifepathData,
+    table_name: &str,
+    age: i32,
+    roller: &mut dyn DieRoller,
+    events: &mut Vec<LifepathEvent>,
+    depth: i32,
+) {
+    assert!(
+        depth < 10,
+        "lifepath table loop detected at '{}'",
+        table_name
+    );
+    let table = data
+        .tables
+        .get(table_name)
+        .unwrap_or_else(|| panic!("lifepath table '{}' missing", table_name));
+    let roll = roller.d10();
+    let entry = table
+        .entries
+        .iter()
+        .find(|entry| (entry.min..=entry.max).contains(&roll))
+        .unwrap_or_else(|| panic!("table '{}' has no entry for roll {}", table_name, roll));
+    events.push(LifepathEvent {
+        age,
+        table: table.title.clone(),
+        text: entry.text.clone(),
+    });
+    if let Some(next) = &entry.goto {
+        resolve_table(data, next, age, roller, events, depth + 1);
+    }
+}
+
+/// Rolls the one-time background tables (family, childhood, personality …).
+pub fn roll_background(variant: LifepathVariant, roller: &mut dyn DieRoller) -> Vec<LifepathEvent> {
+    let data = lifepath_data(variant);
+    let mut events = Vec::new();
+    for table_name in &data.background {
+        resolve_table(&data, table_name, 0, roller, &mut events, 0);
+    }
+    events
+}
+
+/// Rolls the yearly life events for every year above 15 up to `age`.
+pub fn roll_life_events(
+    variant: LifepathVariant,
+    age: i32,
+    roller: &mut dyn DieRoller,
+) -> Vec<LifepathEvent> {
+    let data = lifepath_data(variant);
+    let mut events = Vec::new();
+    for year in 16..=age {
+        resolve_table(&data, &data.yearly, year, roller, &mut events, 0);
+    }
+    events
+}
+
+// --------------------------------------------------------------------------
+// NSC generation
+// --------------------------------------------------------------------------
+
+/// Generates a rules-valid NSC skeleton: random attributes (60 points,
+/// INT/REF ≥ 5, all 2..=9), rolled background and life events.
+/// Skills, advantages and gear stay empty — that's the GM's flavor work.
+pub fn generate_nsc(
+    name: String,
+    role: String,
+    age: i32,
+    variant: LifepathVariant,
+    roller: &mut dyn DieRoller,
+) -> (Character, Vec<LifepathEvent>) {
+    // start at the minimums, then spread the remaining points randomly
+    let mut values: BTreeMap<Attribute, i32> = [
+        (Attribute::Attractiveness, 2),
+        (Attribute::Move, 2),
+        (Attribute::Coolness, 2),
+        (Attribute::Empathy, 2),
+        (Attribute::Luck, 2),
+        (Attribute::Intelligence, 5),
+        (Attribute::Body, 2),
+        (Attribute::Reflexes, 5),
+        (Attribute::Tech, 2),
+    ]
+    .into();
+    let attributes: Vec<Attribute> = values.keys().copied().collect();
+    let mut remaining = ATTRIBUTE_POINTS - values.values().sum::<i32>();
+    while remaining > 0 {
+        let pick = attributes[(roller.d10() - 1) as usize % attributes.len()];
+        let value = values.get_mut(&pick).unwrap();
+        if *value < 9 {
+            *value += 1;
+            remaining -= 1;
+        }
+    }
+
+    let character = Character::new(
+        name,
+        role,
+        age,
+        values[&Attribute::Attractiveness],
+        values[&Attribute::Move],
+        values[&Attribute::Coolness],
+        values[&Attribute::Empathy],
+        values[&Attribute::Luck],
+        values[&Attribute::Intelligence],
+        values[&Attribute::Body],
+        values[&Attribute::Reflexes],
+        values[&Attribute::Tech],
+    );
+
+    let mut events = roll_background(variant, roller);
+    events.append(&mut roll_life_events(variant, age, roller));
+    (character, events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::advantages::{Advantage, ModifierTarget};
+    use crate::dice::{RandomRoller, SequenceRoller};
+
+    fn valid_character() -> Character {
+        // 60 points: 5+5+9+7+7+7+7+7+6 = 60
+        Character::new(
+            "Testfall".to_string(),
+            "Tech".to_string(),
+            25,
+            7, // att
+            7, // mov
+            7, // coo
+            7, // emp
+            6, // luck
+            5, // int
+            9, // body
+            5, // refl
+            7, // tec
+        )
+    }
+
+    #[test]
+    fn test_validate_attributes_accepts_valid_spread() {
+        assert_eq!(validate_attributes(&valid_character()), Ok(()));
+    }
+
+    #[test]
+    fn test_validate_attributes_rejects_violations() {
+        // INT 4 (< 5) and a 10: two errors plus whatever the sum says
+        let character = Character::new(
+            "K".to_string(),
+            "R".to_string(),
+            20,
+            7,
+            7,
+            7,
+            7,
+            6,
+            4,
+            10,
+            5,
+            7,
+        );
+        let errors = validate_attributes(&character).unwrap_err();
+        assert!(errors.iter().any(|error| error.contains("Intelligence")));
+        assert!(errors.iter().any(|error| error.contains("outside 2..=9")));
+    }
+
+    #[test]
+    fn test_age_points_table() {
+        assert_eq!(age_points(15), 0);
+        assert_eq!(age_points(16), 1);
+        assert_eq!(age_points(24), 9);
+        assert_eq!(age_points(25), 11);
+        assert_eq!(age_points(32), 29);
+        assert_eq!(age_points(34), 35);
+    }
+
+    #[test]
+    fn test_skill_point_pool() {
+        // INT 5 + REF 5 + 40 + age 25 -> 11 = 61
+        assert_eq!(skill_point_pool(&valid_character()), 61);
+    }
+
+    #[test]
+    fn test_skill_cost_is_cumulative() {
+        assert_eq!(skill_cost(1), 1);
+        assert_eq!(skill_cost(3), 6);
+        assert_eq!(skill_cost(8), 36);
+    }
+
+    fn skill(name: &str, level: i32) -> Skill {
+        Skill::new(name.to_string(), Attribute::Reflexes, level, 1)
+    }
+
+    #[test]
+    fn test_skill_caps_default_slots() {
+        let skills = vec![skill("a", 8), skill("b", 7), skill("c", 6), skill("d", 6)];
+        assert!(validate_skill_caps(&skills).is_ok());
+        let too_many = vec![skill("a", 8), skill("b", 8)];
+        assert!(validate_skill_caps(&too_many).is_err());
+    }
+
+    #[test]
+    fn test_skill_caps_trade_down() {
+        // wiki example: three 7s and two 6s, but no 8
+        let skills = vec![
+            skill("a", 7),
+            skill("b", 7),
+            skill("c", 7),
+            skill("d", 6),
+            skill("e", 6),
+        ];
+        assert!(validate_skill_caps(&skills).is_ok());
+        // four 7s is one too many even after the trade
+        let skills = vec![skill("a", 7), skill("b", 7), skill("c", 7), skill("d", 7)];
+        assert!(validate_skill_caps(&skills).is_err());
+    }
+
+    #[test]
+    fn test_skill_budget_with_advantages() {
+        let mut character = valid_character(); // pool 61
+        character.skills.push(skill("Pistole", 8)); // 36
+        character.skills.push(skill("Fahren", 5)); // 15
+        character.advantages.push(Advantage::new(
+            "Lesen und Schreiben".to_string(),
+            AdvantageKind::Advantage,
+            10,
+            String::new(),
+        ));
+        // 36 + 15 + 10 = 61: exactly the pool
+        assert_eq!(validate_skill_budget(&character), Ok(0));
+
+        // a disadvantage grants points back
+        character.advantages.push(Advantage::new(
+            "Ehrlich".to_string(),
+            AdvantageKind::Disadvantage,
+            5,
+            String::new(),
+        ));
+        assert_eq!(validate_skill_budget(&character), Ok(5));
+    }
+
+    #[test]
+    fn test_starting_money() {
+        let mut character = valid_character();
+        character.skills.push(skill("Basic Tech", 6));
+        character.skills.push(skill("Elektrotechnik", 4));
+        character.skills.push(skill("Schweißen", 2));
+        let money =
+            starting_money(&character, &["Basic Tech", "Elektrotechnik", "Schweißen"]).unwrap();
+        assert_eq!(money, 12 * 350);
+
+        // Reich level 2 quadruples the factor
+        character.advantages.push(
+            Advantage::new(
+                "Reich".to_string(),
+                AdvantageKind::Advantage,
+                4,
+                String::new(),
+            )
+            .with_level(2)
+            .with_modifier(ModifierTarget::Tag("reich".to_string()), 2),
+        );
+        let money =
+            starting_money(&character, &["Basic Tech", "Elektrotechnik", "Schweißen"]).unwrap();
+        assert_eq!(money, 12 * 1400);
+
+        assert!(starting_money(&character, &["Basic Tech", "Nope", "Schweißen"]).is_err());
+    }
+
+    #[test]
+    fn test_lifepath_data_parses_and_resolves() {
+        for variant in [LifepathVariant::Classic, LifepathVariant::Desaster] {
+            let mut roller = RandomRoller;
+            let background = roll_background(variant, &mut roller);
+            assert!(!background.is_empty());
+            // three years -> at least three events (subtables add more)
+            let events = roll_life_events(variant, 18, &mut roller);
+            assert!(events.len() >= 3);
+            assert_eq!(
+                events.iter().filter(|event| event.age == 16).count() >= 1,
+                true
+            );
+        }
+    }
+
+    #[test]
+    fn test_lifepath_is_deterministic_with_scripted_dice() {
+        // year 16: master roll 9 -> "Nothing happened" (no subtable)
+        let mut roller = SequenceRoller::new(vec![9]);
+        let events = roll_life_events(LifepathVariant::Classic, 16, &mut roller);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].age, 16);
+    }
+
+    #[test]
+    fn test_generate_nsc_is_rules_valid() {
+        let mut roller = RandomRoller;
+        for _ in 0..20 {
+            let (character, events) = generate_nsc(
+                "NSC".to_string(),
+                "Ganger".to_string(),
+                20,
+                LifepathVariant::Desaster,
+                &mut roller,
+            );
+            assert_eq!(validate_attributes(&character), Ok(()));
+            assert!(!events.is_empty());
+        }
+    }
+}

--- a/src/dice.rs
+++ b/src/dice.rs
@@ -1,19 +1,28 @@
-/// Source of raw d10 rolls.
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Source of raw die rolls.
 ///
 /// The rules engine never calls the RNG directly; it always goes through this
 /// trait so tests can script exact die sequences and a future server can
 /// record and replay rolls.
 pub trait DieRoller {
+    /// Rolls a single die with `sides` faces, returning a value in 1..=sides.
+    fn die(&mut self, sides: i32) -> i32;
+
     /// Rolls a single d10, returning a value in 1..=10.
-    fn d10(&mut self) -> i32;
+    fn d10(&mut self) -> i32 {
+        self.die(10)
+    }
 }
 
-/// The real thing: uniformly random d10s.
+/// The real thing: uniformly random dice.
 pub struct RandomRoller;
 
 impl DieRoller for RandomRoller {
-    fn d10(&mut self) -> i32 {
-        rand::random_range(1..=10)
+    fn die(&mut self, sides: i32) -> i32 {
+        rand::random_range(1..=sides)
     }
 }
 
@@ -22,7 +31,7 @@ impl DieRoller for RandomRoller {
 /// # Panics
 ///
 /// Panics when more rolls are requested than values were provided, or when a
-/// value is outside 1..=10.
+/// value is outside the requested die's range.
 pub struct SequenceRoller {
     values: Vec<i32>,
     next: usize,
@@ -35,19 +44,102 @@ impl SequenceRoller {
 }
 
 impl DieRoller for SequenceRoller {
-    fn d10(&mut self) -> i32 {
+    fn die(&mut self, sides: i32) -> i32 {
         let value = *self
             .values
             .get(self.next)
             .expect("SequenceRoller ran out of scripted values");
         assert!(
-            (1..=10).contains(&value),
-            "SequenceRoller value out of d10 range: {}",
+            (1..=sides).contains(&value),
+            "SequenceRoller value out of d{} range: {}",
+            sides,
             value
         );
         self.next += 1;
         value
     }
+}
+
+/// A dice expression like `5d6` or `2d6+2`, used for weapon and
+/// martial-arts damage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiceExpr {
+    pub count: i32,
+    pub sides: i32,
+    pub bonus: i32,
+}
+
+impl DiceExpr {
+    pub fn new(count: i32, sides: i32, bonus: i32) -> Self {
+        DiceExpr {
+            count,
+            sides,
+            bonus,
+        }
+    }
+
+    pub fn roll(&self, roller: &mut dyn DieRoller) -> i32 {
+        (0..self.count).map(|_| roller.die(self.sides)).sum::<i32>() + self.bonus
+    }
+
+    /// The table's "average damage" as used by the shot-noise formula:
+    /// `count * (sides / 2) + bonus` with integer halving
+    /// (AK 5d6 → 15, Grach 2d6+2 → 8, matching the wiki examples).
+    pub fn average(&self) -> i32 {
+        self.count * (self.sides / 2) + self.bonus
+    }
+}
+
+impl fmt::Display for DiceExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}d{}", self.count, self.sides)?;
+        if self.bonus > 0 {
+            write!(f, "+{}", self.bonus)?;
+        } else if self.bonus < 0 {
+            write!(f, "{}", self.bonus)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for DiceExpr {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let error = || format!("Invalid dice expression: '{}'", s);
+        let (count, rest) = s.split_once(['d', 'D']).ok_or_else(error)?;
+        let (sides, bonus) = if let Some((sides, bonus)) = rest.split_once('+') {
+            (sides, bonus.parse::<i32>().map_err(|_| error())?)
+        } else if let Some((sides, malus)) = rest.split_once('-') {
+            (sides, -malus.parse::<i32>().map_err(|_| error())?)
+        } else {
+            (rest, 0)
+        };
+        Ok(DiceExpr {
+            count: count.parse().map_err(|_| error())?,
+            sides: sides.parse().map_err(|_| error())?,
+            bonus,
+        })
+    }
+}
+
+impl Serialize for DiceExpr {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for DiceExpr {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// Rolls a uniform number in 0..=999 from three d10s (each die read as a
+/// digit, 10 = 0). Used for per-mille chances like the crippling roll.
+pub fn roll_per_mille(roller: &mut dyn DieRoller) -> i32 {
+    (roller.d10() % 10) * 100 + (roller.d10() % 10) * 10 + (roller.d10() % 10)
 }
 
 /// Standard difficulties from the house rules: easy 10+, normal 15+, hard 20+.
@@ -354,5 +446,40 @@ mod tests {
         let mut roller = SequenceRoller::new(vec![5]);
         roller.d10();
         roller.d10();
+    }
+
+    #[test]
+    fn test_dice_expr_parse_display_roundtrip() {
+        for s in ["5d6", "2d6+2", "1d3", "4d10", "2d6-1"] {
+            let expr: DiceExpr = s.parse().unwrap();
+            assert_eq!(expr.to_string(), s);
+        }
+        assert!("d6".parse::<DiceExpr>().is_err());
+        assert!("2w6".parse::<DiceExpr>().is_err());
+    }
+
+    #[test]
+    fn test_dice_expr_average_matches_wiki_examples() {
+        // AK 5d6 -> 15, 9mm 2d6+2 -> 8 (noise formula examples)
+        assert_eq!("5d6".parse::<DiceExpr>().unwrap().average(), 15);
+        assert_eq!("2d6+2".parse::<DiceExpr>().unwrap().average(), 8);
+    }
+
+    #[test]
+    fn test_dice_expr_roll() {
+        let expr: DiceExpr = "2d6+3".parse().unwrap();
+        let mut roller = SequenceRoller::new(vec![4, 6]);
+        assert_eq!(expr.roll(&mut roller), 13);
+    }
+
+    #[test]
+    fn test_random_roller_die_range() {
+        let mut roller = RandomRoller;
+        for sides in [3, 6, 10] {
+            for _ in 0..200 {
+                let roll = roller.die(sides);
+                assert!((1..=sides).contains(&roll));
+            }
+        }
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,4 +1,5 @@
 use crate::armor::Armor;
+use crate::weapons::Weapon;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::fmt;
@@ -36,11 +37,15 @@ struct SerializeableInventory {
     items: Vec<SerializeableInventoryItem>,
 }
 
+// the variant names are the `type = "..."` tags in saved character files —
+// the Item postfix is intentional there
+#[allow(clippy::enum_variant_names)]
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 enum SerializeableInventoryItem {
     BasicItem(Item),
     ArmorItem(Armor),
+    WeaponItem(Weapon),
 }
 
 impl PartialEq for Inventory {
@@ -66,6 +71,8 @@ impl Serialize for Inventory {
         for item in &self.items {
             if let Some(armor) = item.as_any().downcast_ref::<Armor>() {
                 serializable_items.push(SerializeableInventoryItem::ArmorItem(armor.clone()));
+            } else if let Some(weapon) = item.as_any().downcast_ref::<Weapon>() {
+                serializable_items.push(SerializeableInventoryItem::WeaponItem(weapon.clone()));
             } else if let Some(basic) = item.as_any().downcast_ref::<Item>() {
                 serializable_items.push(SerializeableInventoryItem::BasicItem(basic.clone()));
             } else {
@@ -94,6 +101,7 @@ impl<'de> Deserialize<'de> for Inventory {
             match item {
                 SerializeableInventoryItem::BasicItem(basic) => items.push(Box::new(basic)),
                 SerializeableInventoryItem::ArmorItem(armor) => items.push(Box::new(armor)),
+                SerializeableInventoryItem::WeaponItem(weapon) => items.push(Box::new(weapon)),
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod advantages;
 mod armor;
 mod character;
+mod chargen;
 mod dice;
 mod health;
 mod inventory;
@@ -8,11 +9,16 @@ mod melee;
 mod weapons;
 
 pub use self::advantages::{
-    validate_budget, Advantage, AdvantageKind, Modifier, ModifierTarget, TAG_BRUISE_SCALE,
-    TAG_HEALING_RATE, TAG_INITIATIVE,
+    advantage_catalog, validate_budget, Advantage, AdvantageKind, Modifier, ModifierTarget,
+    TAG_BRUISE_SCALE, TAG_HEALING_RATE, TAG_INITIATIVE,
 };
 pub use self::armor::{Armor, HitZone};
 pub use self::character::{Attribute, AttributeValue, Character, HitOutcome, List, Skill};
+pub use self::chargen::{
+    age_points, generate_nsc, roll_background, roll_life_events, skill_cost, skill_point_pool,
+    starting_money, validate_attributes, validate_character, validate_skill_budget,
+    validate_skill_caps, LifepathEvent, LifepathVariant, ATTRIBUTE_POINTS,
+};
 pub use self::dice::{open_roll, skill_check};
 pub use self::dice::{
     CheckResult, DiceExpr, DieRoller, Difficulty, OpenRollResult, Outcome, RandomRoller,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod character;
 mod dice;
 mod health;
 mod inventory;
+mod melee;
 mod weapons;
 
 pub use self::advantages::{
@@ -14,8 +15,13 @@ pub use self::armor::{Armor, HitZone};
 pub use self::character::{Attribute, AttributeValue, Character, HitOutcome, List, Skill};
 pub use self::dice::{open_roll, skill_check};
 pub use self::dice::{
-    CheckResult, DieRoller, Difficulty, OpenRollResult, Outcome, RandomRoller, SequenceRoller,
+    CheckResult, DiceExpr, DieRoller, Difficulty, OpenRollResult, Outcome, RandomRoller,
+    SequenceRoller,
 };
 pub use self::health::WoundState;
 pub use self::inventory::{Inventory, Item};
+pub use self::melee::{
+    dam_for_body, MartialArtsAction, MartialArtsStyle, MeleeClass, MELEE_GENERAL_CAP,
+    SKILL_MELEE_GENERAL,
+};
 pub use self::weapons::DamageType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,7 @@ pub use self::melee::{
     dam_for_body, MartialArtsAction, MartialArtsStyle, MeleeClass, MELEE_GENERAL_CAP,
     SKILL_MELEE_GENERAL,
 };
-pub use self::weapons::DamageType;
+pub use self::weapons::{
+    autofire_attack_modifier, autofire_hits, burst_hits, shot_noise_bonus, Availability,
+    Concealability, DamageType, Reliability, Weapon, WeaponCategory, BURST_ATTACK_BONUS,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,48 @@
 use rusted_punk::{
-    Armor, Attribute, Character, DamageType, Difficulty, HitZone, Item, List, RandomRoller, Skill,
+    generate_nsc, Armor, Attribute, Character, DamageType, Difficulty, HitZone, Item,
+    LifepathVariant, List, RandomRoller, Skill,
 };
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() > 1 && args[1] == "chargen" {
+        chargen_command(&args[2..]);
+        return;
+    }
     armor_test();
     character_test();
     skill_test();
     list_test();
     dice_test();
+}
+
+/// `cargo run -- chargen [--classic|--desaster] [name] [role] [age]`
+/// Rolls an NSC skeleton: valid random attributes plus lifepath (Q29).
+fn chargen_command(args: &[String]) {
+    let variant = if args.iter().any(|arg| arg == "--desaster") {
+        LifepathVariant::Desaster
+    } else {
+        LifepathVariant::Classic
+    };
+    let positional: Vec<&String> = args.iter().filter(|arg| !arg.starts_with("--")).collect();
+    let name = positional.first().map_or("NSC", |s| s.as_str()).to_string();
+    let role = positional
+        .get(1)
+        .map_or("Ganger", |s| s.as_str())
+        .to_string();
+    let age = positional.get(2).and_then(|s| s.parse().ok()).unwrap_or(22);
+
+    let mut roller = RandomRoller;
+    let (character, events) = generate_nsc(name, role, age, variant, &mut roller);
+    character.print();
+    println!("Lifepath ({:?}):", variant);
+    for event in events {
+        if event.age > 0 {
+            println!("  [{}] {}: {}", event.age, event.table, event.text);
+        } else {
+            println!("  {}: {}", event.table, event.text);
+        }
+    }
 }
 
 fn dice_test() {

--- a/src/melee.rs
+++ b/src/melee.rs
@@ -1,0 +1,193 @@
+use crate::dice::DiceExpr;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Name of the shared melee base skill ("Nahkampf allgemein", includes Dodge).
+/// Capped at level 3; above that the weapon classes specialize.
+pub const SKILL_MELEE_GENERAL: &str = "Nahkampf";
+
+/// The general melee level cap: beyond this, only specializations grow.
+pub const MELEE_GENERAL_CAP: i32 = 3;
+
+/// Melee weapon classes, the specializations above general level 3.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MeleeClass {
+    /// Knives etc.
+    Short,
+    /// Swords, clubs etc.
+    Medium,
+    /// Spears, battle staffs etc.
+    Long,
+}
+
+impl MeleeClass {
+    /// The skill name of this specialization on the character sheet.
+    pub fn skill_name(self) -> &'static str {
+        match self {
+            MeleeClass::Short => "Nahkampf Kurz",
+            MeleeClass::Medium => "Nahkampf Mittel",
+            MeleeClass::Long => "Nahkampf Lang",
+        }
+    }
+}
+
+impl fmt::Display for MeleeClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.skill_name())
+    }
+}
+
+/// Martial arts styles at the table (Q26).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MartialArtsStyle {
+    /// Brawling: no key attacks.
+    Pruegeln,
+    /// Boxing: +3 Punch, +3 Sweep, +1 Block.
+    Boxen,
+    /// Wrestling: +2 Sweep, +4 Grapple, +3 Throw, +4 Hold, +2 Choke, +4 Escape.
+    Ringen,
+}
+
+impl MartialArtsStyle {
+    pub fn skill_name(self) -> &'static str {
+        match self {
+            MartialArtsStyle::Pruegeln => "Kampfkunst Prügeln",
+            MartialArtsStyle::Boxen => "Kampfkunst Boxen",
+            MartialArtsStyle::Ringen => "Kampfkunst Ringen",
+        }
+    }
+
+    /// The style's key-attack bonus for an action, added to the attack roll.
+    pub fn key_attack_bonus(self, action: MartialArtsAction) -> i32 {
+        use MartialArtsAction::*;
+        match self {
+            MartialArtsStyle::Pruegeln => 0,
+            MartialArtsStyle::Boxen => match action {
+                Punch | Sweep => 3,
+                Block => 1,
+                _ => 0,
+            },
+            MartialArtsStyle::Ringen => match action {
+                Grapple | Hold | Escape => 4,
+                Throw => 3,
+                Sweep | Choke => 2,
+                _ => 0,
+            },
+        }
+    }
+}
+
+impl fmt::Display for MartialArtsStyle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.skill_name())
+    }
+}
+
+/// Martial arts actions (wiki Kampfkunstaktionen + the styles' key attacks).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MartialArtsAction {
+    /// Strike: 1d3 + DAM + skill (head, torso, arms).
+    Punch,
+    /// 1d6 + DAM + skill (legs, torso, arms).
+    Kick,
+    /// Leg sweep: sends the opponent to the ground, no damage.
+    Sweep,
+    /// Reduces damage.
+    Block,
+    /// Evades the damage entirely (−2 on the attack).
+    Dodge,
+    /// Knocks the opponent's weapon away.
+    Disarm,
+    /// Preparation for Throw, Hold or Choke.
+    Grapple,
+    /// After a grapple: 1d6 + DAM + skill, stun check at −2.
+    Throw,
+    /// Pins the opponent; +1 for every round the hold persists.
+    Hold,
+    /// Counter to Grapple or Hold.
+    Escape,
+    /// 1d6 + skill per round at the grapple/hold position.
+    Choke,
+}
+
+impl MartialArtsAction {
+    /// Base damage dice of this action, before DAM and skill level.
+    /// `None` for actions that don't deal damage directly.
+    pub fn base_damage(self) -> Option<DiceExpr> {
+        use MartialArtsAction::*;
+        match self {
+            Punch => Some(DiceExpr::new(1, 3, 0)),
+            Kick | Throw | Choke => Some(DiceExpr::new(1, 6, 0)),
+            _ => None,
+        }
+    }
+
+    /// Whether the DAM body modifier applies to this action's damage
+    /// (it doesn't for choking — that's technique, not mass).
+    pub fn applies_dam(self) -> bool {
+        !matches!(self, MartialArtsAction::Choke)
+    }
+}
+
+/// The hand-to-hand damage modifier (DAM / "DAMAGE MOD" on the character
+/// sheet), per the CP2020 damage modifiers table in Reference Book 5.
+pub fn dam_for_body(body: i32) -> i32 {
+    match body {
+        ..=2 => -2,
+        3..=4 => -1,
+        5..=7 => 0,
+        8..=9 => 1,
+        10 => 2,
+        11..=12 => 4,
+        13..=14 => 6,
+        _ => 8,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dam_table_boundaries() {
+        assert_eq!(dam_for_body(2), -2);
+        assert_eq!(dam_for_body(3), -1);
+        assert_eq!(dam_for_body(5), 0);
+        assert_eq!(dam_for_body(8), 1);
+        assert_eq!(dam_for_body(10), 2);
+        assert_eq!(dam_for_body(11), 4);
+        assert_eq!(dam_for_body(14), 6);
+        assert_eq!(dam_for_body(15), 8);
+    }
+
+    #[test]
+    fn test_key_attack_bonuses() {
+        use MartialArtsAction::*;
+        use MartialArtsStyle::*;
+        assert_eq!(Pruegeln.key_attack_bonus(Punch), 0);
+        assert_eq!(Boxen.key_attack_bonus(Punch), 3);
+        assert_eq!(Boxen.key_attack_bonus(Sweep), 3);
+        assert_eq!(Boxen.key_attack_bonus(Block), 1);
+        assert_eq!(Boxen.key_attack_bonus(Grapple), 0);
+        assert_eq!(Ringen.key_attack_bonus(Grapple), 4);
+        assert_eq!(Ringen.key_attack_bonus(Throw), 3);
+        assert_eq!(Ringen.key_attack_bonus(Hold), 4);
+        assert_eq!(Ringen.key_attack_bonus(Choke), 2);
+        assert_eq!(Ringen.key_attack_bonus(Escape), 4);
+        assert_eq!(Ringen.key_attack_bonus(Punch), 0);
+    }
+
+    #[test]
+    fn test_base_damage() {
+        assert_eq!(
+            MartialArtsAction::Punch.base_damage(),
+            Some(DiceExpr::new(1, 3, 0))
+        );
+        assert_eq!(
+            MartialArtsAction::Kick.base_damage(),
+            Some(DiceExpr::new(1, 6, 0))
+        );
+        assert_eq!(MartialArtsAction::Block.base_damage(), None);
+        assert_eq!(MartialArtsAction::Sweep.base_damage(), None);
+    }
+}

--- a/src/weapons.rs
+++ b/src/weapons.rs
@@ -1,3 +1,5 @@
+use crate::dice::DiceExpr;
+use crate::inventory::{InventoryItem, Item};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -7,6 +9,8 @@ pub enum DamageType {
     Slashing,
     ArmorPiercing,
     HollowPoint,
+    /// Fire (Molotov etc.): ignores the ">8 damage" crippling rule.
+    Fire,
 }
 
 impl fmt::Display for DamageType {
@@ -15,9 +19,318 @@ impl fmt::Display for DamageType {
     }
 }
 
+/// Weapon categories per issue #21.
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy, Serialize, Deserialize)]
+pub enum WeaponCategory {
+    Knife,
+    Club,
+    Axe,
+    Spear,
+    BrassKnuckles,
+    Pistol,
+    Smg,
+    Rifle,
+    Shotgun,
+    Bow,
+    RocketLauncher,
+    Sling,
+    Shuriken,
+    Molotov,
+}
+
+impl WeaponCategory {
+    /// Melee weapons add the wielder's DAM to damage and map to a
+    /// melee weapon class for the skill roll.
+    pub fn melee_class(self) -> Option<crate::melee::MeleeClass> {
+        use crate::melee::MeleeClass;
+        match self {
+            WeaponCategory::Knife | WeaponCategory::BrassKnuckles => Some(MeleeClass::Short),
+            WeaponCategory::Club | WeaponCategory::Axe => Some(MeleeClass::Medium),
+            WeaponCategory::Spear => Some(MeleeClass::Long),
+            _ => None,
+        }
+    }
+
+    /// Firearms are subject to the penetration cap (4 + 1d10 before the
+    /// shot exits through the back).
+    pub fn is_gunshot(self) -> bool {
+        matches!(
+            self,
+            WeaponCategory::Pistol
+                | WeaponCategory::Smg
+                | WeaponCategory::Rifle
+                | WeaponCategory::Shotgun
+        )
+    }
+}
+
+/// CP2020 concealability rating.
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
+pub enum Concealability {
+    /// P — pocket, pants leg or sleeve.
+    Pocket,
+    /// J — jacket, coat or shoulder rig.
+    Jacket,
+    /// L — long coat.
+    LongCoat,
+    /// N — can't be hidden.
+    NoHide,
+}
+
+/// CP2020 availability rating; the workshop trading system maps this
+/// to token difficulties (common 10, rare 20, legendary 40).
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
+pub enum Availability {
+    /// E — excellent, can be found almost anywhere.
+    Excellent,
+    /// C — common, most stores and black marketeers.
+    Common,
+    /// P — poor, specialty stores, black market.
+    Poor,
+    /// R — rare, custom order, stolen or very hard to find.
+    Rare,
+}
+
+/// CP2020 reliability rating (matters on fumbles with autofire etc.).
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
+pub enum Reliability {
+    VeryReliable,
+    Standard,
+    Unreliable,
+}
+
+/// A weapon, stats per CP2020 Reference Book 5 (see PROJECT-STRUCTURE §3).
+// Field order matters for TOML: the table-like `item` must serialize last.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct Weapon {
+    pub category: WeaponCategory,
+    /// Weapon accuracy (WA), added to attack rolls.
+    pub weapon_accuracy: i32,
+    pub concealability: Concealability,
+    pub availability: Availability,
+    pub damage: DiceExpr,
+    pub damage_type: DamageType,
+    /// Magazine size; 0 for melee weapons.
+    pub magazine: i32,
+    /// Maximum shots per round; 0 for melee weapons.
+    pub rate_of_fire: i32,
+    pub reliability: Reliability,
+    /// Effective range in meters; melee weapons use their reach here.
+    pub range_m: i32,
+    pub silencer: bool,
+    pub scope: bool,
+    pub item: Item,
+}
+
+impl InventoryItem for Weapon {
+    fn get_item(&self) -> &Item {
+        &self.item
+    }
+
+    fn get_item_mut(&mut self) -> &mut Item {
+        &mut self.item
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn equals(&self, other: &dyn InventoryItem) -> bool {
+        if let Some(other_weapon) = other.as_any().downcast_ref::<Weapon>() {
+            self == other_weapon
+        } else {
+            false
+        }
+    }
+}
+
+impl fmt::Display for Weapon {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} ({:?}, WA {:+}, {} {})",
+            self.item, self.category, self.weapon_accuracy, self.damage, self.damage_type
+        )
+    }
+}
+
+/// The noise bonus for hearing a shot (roll vs 15), per the Hausregeln
+/// formula: average damage × 3, −2 per wall, −6 per soundproofed wall,
+/// −2 per 50 m distance, +2 per bullet fired that round. A silencer halves
+/// the initial loudness. Direction is known if the check succeeds by 10+.
+pub fn shot_noise_bonus(
+    weapon: &Weapon,
+    bullets_this_round: i32,
+    distance_m: i32,
+    walls: i32,
+    soundproofed_walls: i32,
+) -> i32 {
+    let mut initial = weapon.damage.average() * 3;
+    if weapon.silencer {
+        initial /= 2;
+    }
+    initial - 2 * walls - 6 * soundproofed_walls - 2 * (distance_m / 50) + 2 * bullets_this_round
+}
+
+impl Weapon {
+    #[allow(clippy::too_many_arguments)] // catalog constructor, named per column
+    fn catalog_entry(
+        name: &str,
+        category: WeaponCategory,
+        weapon_accuracy: i32,
+        concealability: Concealability,
+        availability: Availability,
+        damage: &str,
+        damage_type: DamageType,
+        magazine: i32,
+        rate_of_fire: i32,
+        reliability: Reliability,
+        range_m: i32,
+        price_eb: i32,
+        weight_grams: i32,
+        comment: &str,
+    ) -> Weapon {
+        Weapon {
+            item: Item::new(
+                None,
+                name.to_string(),
+                1,
+                weight_grams,
+                price_eb,
+                comment.to_string(),
+            ),
+            category,
+            weapon_accuracy,
+            concealability,
+            availability,
+            damage: damage.parse().expect("catalog dice expression"),
+            damage_type,
+            magazine,
+            rate_of_fire,
+            reliability,
+            range_m,
+            silencer: false,
+            scope: false,
+        }
+    }
+
+    /// One middle-of-the-road CP2020 representative per category from
+    /// issue #21 (Q27). Stats from Reference Book 5; weights are estimates.
+    /// Sling and Molotov have no RB5 entries — best-guess stats, marked
+    /// in the comment for review.
+    pub fn catalog() -> Vec<Weapon> {
+        use Availability::*;
+        use Concealability::*;
+        use Reliability::*;
+        use WeaponCategory::*;
+        vec![
+            Weapon::catalog_entry(
+                "Combat Knife", Knife, 1, Jacket, Poor, "1d6+3",
+                DamageType::Slashing, 0, 0, VeryReliable, 1, 70, 400,
+                "RB5: MEL +1 J P 1d6+3 (PAC)",
+            ),
+            Weapon::catalog_entry(
+                "Club", Club, 0, LongCoat, Common, "1d6",
+                DamageType::Blunt, 0, 0, VeryReliable, 1, 2, 800,
+                "RB5: MEL +0 L C 1d6 (CP20)",
+            ),
+            Weapon::catalog_entry(
+                "Axe", Axe, -1, NoHide, Common, "2d6+3",
+                DamageType::Slashing, 0, 0, VeryReliable, 1, 20, 1500,
+                "RB5: MEL -1 N C 2d6+3 (CP20)",
+            ),
+            Weapon::catalog_entry(
+                "Speer", Spear, 0, NoHide, Poor, "3d6",
+                DamageType::Slashing, 0, 0, VeryReliable, 2, 95, 2000,
+                "RB5: Fang Tian Ji, MEL +0 N P 3d6 2m (PAC)",
+            ),
+            Weapon::catalog_entry(
+                "Brass Knuckles", BrassKnuckles, 0, Pocket, Common, "1d6+2",
+                DamageType::Blunt, 0, 0, VeryReliable, 1, 10, 250,
+                "RB5: Punch +0 P C 1d6+2 (CP20)",
+            ),
+            Weapon::catalog_entry(
+                "Militech Arms Avenger", Pistol, 0, Jacket, Excellent, "2d6+1",
+                DamageType::Blunt, 10, 2, VeryReliable, 50, 250, 1000,
+                "RB5: P +0 J E 2d6+1 (9mm) 10/2 VR 50m (CP20)",
+            ),
+            Weapon::catalog_entry(
+                "Uzi Miniauto 9", Smg, 1, Jacket, Excellent, "2d6+1",
+                DamageType::Blunt, 30, 35, VeryReliable, 150, 475, 3000,
+                "RB5: SMG +1 J E 2d6+1 (9mm) 30/35 VR 150m (CP20)",
+            ),
+            Weapon::catalog_entry(
+                "AK-47", Rifle, 0, NoHide, Excellent, "5d6",
+                DamageType::ArmorPiercing, 30, 20, VeryReliable, 400, 300, 4300,
+                "RB5: RIF +0 N E 5d6 (7.62sov) 30/20 VR 400m (CP20); Technlogien-Seite",
+            ),
+            Weapon::catalog_entry(
+                "Ithaca Stakeout", Shotgun, -1, LongCoat, Common, "4d6",
+                DamageType::Blunt, 8, 2, Standard, 50, 200, 3200,
+                "RB5: SHT -1 L C 4d6 (12ga) 8/2 ST 50m (CP13)",
+            ),
+            Weapon::catalog_entry(
+                "TomKatt Hunting Bow", Bow, 0, NoHide, Common, "4d6",
+                DamageType::ArmorPiercing, 12, 1, VeryReliable, 150, 150, 1400,
+                "RB5: BOW +0 N C 4d6 12/1 VR 150m (CGen)",
+            ),
+            Weapon::catalog_entry(
+                "LAW", RocketLauncher, -2, LongCoat, Poor, "4d10",
+                DamageType::ArmorPiercing, 1, 1, VeryReliable, 200, 300, 2500,
+                "RB5: HVY -2 L P 4d10 HEAT 2m radius, single use (MM)",
+            ),
+            Weapon::catalog_entry(
+                "Schleuder", Sling, -1, Pocket, Excellent, "1d6",
+                DamageType::Blunt, 1, 1, VeryReliable, 50, 1, 100,
+                "BEST GUESS (kein RB5-Eintrag): improvisierte Steinschleuder — bitte reviewen",
+            ),
+            Weapon::catalog_entry(
+                "Bo-Shuriken", Shuriken, 0, Pocket, Common, "1d6",
+                DamageType::ArmorPiercing, 1, 1, VeryReliable, 10, 5, 50,
+                "RB5: MEL +0 P C 1d6 Throw (PAC)",
+            ),
+            Weapon::catalog_entry(
+                "Molotov-Cocktail", Molotov, -1, Jacket, Excellent, "2d10",
+                DamageType::Fire, 1, 1, Unreliable, 20, 5, 900,
+                "BEST GUESS (kein RB5-Eintrag): 2d10 Feuer im 2m-Radius, brennt weiter — bitte reviewen",
+            ),
+        ]
+    }
+}
+
+/// Autofire (house rule): +1 on the attack per 10 bullets when close,
+/// −1 per 10 when far; on a success one bullet hits per point above the
+/// target, capped at the bullets fired. No precision bonuses apply.
+pub fn autofire_attack_modifier(bullets: i32, close: bool) -> i32 {
+    let per_ten = bullets / 10;
+    if close {
+        per_ten
+    } else {
+        -per_ten
+    }
+}
+
+/// Bullets that hit after a successful autofire attack.
+pub fn autofire_hits(total: i32, target: i32, bullets: i32) -> i32 {
+    (total - target).max(0).min(bullets)
+}
+
+/// Three-round burst (house rule): +3 on the attack, single target only;
+/// on a success 1d2 bullets hit.
+pub const BURST_ATTACK_BONUS: i32 = 3;
+
+pub fn burst_hits(roller: &mut dyn crate::dice::DieRoller) -> i32 {
+    roller.die(2)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dice::SequenceRoller;
 
     #[test]
     fn test_damage_type_serialization() {
@@ -25,5 +338,76 @@ mod tests {
         let serialized = toml::to_string(&damage_type).unwrap();
         let deserialized: DamageType = toml::from_str(&serialized).unwrap();
         assert_eq!(damage_type, deserialized);
+    }
+
+    #[test]
+    fn test_catalog_covers_all_categories() {
+        let catalog = Weapon::catalog();
+        assert_eq!(catalog.len(), 14);
+        for category in [
+            WeaponCategory::Knife,
+            WeaponCategory::Club,
+            WeaponCategory::Axe,
+            WeaponCategory::Spear,
+            WeaponCategory::BrassKnuckles,
+            WeaponCategory::Pistol,
+            WeaponCategory::Smg,
+            WeaponCategory::Rifle,
+            WeaponCategory::Shotgun,
+            WeaponCategory::Bow,
+            WeaponCategory::RocketLauncher,
+            WeaponCategory::Sling,
+            WeaponCategory::Shuriken,
+            WeaponCategory::Molotov,
+        ] {
+            assert!(
+                catalog.iter().any(|weapon| weapon.category == category),
+                "missing category {:?}",
+                category
+            );
+        }
+    }
+
+    #[test]
+    fn test_shot_noise_matches_wiki_examples() {
+        let catalog = Weapon::catalog();
+        let ak = catalog
+            .iter()
+            .find(|weapon| weapon.item.name == "AK-47")
+            .unwrap();
+        // wiki: AK (5d6) at 200 m -> 45 - 8 = 37... wiki says 38 with -2*4;
+        // 200/50 = 4 walls-equivalents; 45 - 8 = 37. The wiki example counts
+        // "(-2*4) = 38" which is arithmetically off by one (45-8=37);
+        // we implement the formula, not the typo.
+        assert_eq!(shot_noise_bonus(ak, 1, 200, 0, 0), 45 - 8 + 2);
+        // silencer halves the initial 45 -> 22 (integer)
+        let mut silenced = ak.clone();
+        silenced.silencer = true;
+        assert_eq!(shot_noise_bonus(&silenced, 1, 0, 0, 0), 22 + 2);
+    }
+
+    #[test]
+    fn test_autofire_math() {
+        assert_eq!(autofire_attack_modifier(30, true), 3);
+        assert_eq!(autofire_attack_modifier(30, false), -3);
+        assert_eq!(autofire_attack_modifier(9, true), 0);
+        // total 22 vs target 15 with 5 bullets: capped at 5
+        assert_eq!(autofire_hits(22, 15, 5), 5);
+        assert_eq!(autofire_hits(18, 15, 30), 3);
+        assert_eq!(autofire_hits(14, 15, 30), 0);
+    }
+
+    #[test]
+    fn test_burst_hits() {
+        let mut roller = SequenceRoller::new(vec![2]);
+        assert_eq!(burst_hits(&mut roller), 2);
+    }
+
+    #[test]
+    fn test_weapon_serialization() {
+        let weapon = Weapon::catalog().remove(0);
+        let serialized = toml::to_string(&weapon).unwrap();
+        let deserialized: Weapon = toml::from_str(&serialized).unwrap();
+        assert_eq!(weapon, deserialized);
     }
 }


### PR DESCRIPTION
The approved unattended run, one milestone per commit (merge order doesn't matter — it's one branch):

## M4 — Skills with special functions (#15)
- `melee.rs`: Kurz/Mittel/Lang specializations continue the scale independently above the general cap of 3 (test replays Ben's Q23 example: general 3 + Kurz 4 → 1d10+4 short / 1d10+3 medium); Dodge stays on general (Q24); unfamiliar weapons = difficulty +3 (Q25)
- Martial arts: Prügeln (no key attacks), Boxen (+3 Punch/+3 Sweep/+1 Block), Ringen (+2 Sweep/+4 Grapple/+3 Throw/+4 Hold/+2 Choke/+4 Escape); key-attack bonus on the attack roll, skill level 1:1 on damage; DAM table from RB5
- Dice groundwork: `DieRoller::die(sides)`, `DiceExpr` ("5d6+2"), per-mille rolls
- Crippling check (Q22): once per critical+ injury after the fight, 5%/0.5%, Schnelle Heilung 1%/0.1%

## M5 — Weapons (#21)
- `Weapon` as InventoryItem with WA/concealability/**availability+cost (kept for classic CP2020, Q28)**/damage/ROF/reliability/range/silencer/scope
- Catalog: one middle RAW representative per category (Q27), RB5 source lines in comments; **Sling + Molotov are best guesses** (no RB5 entries) — please review
- `DamageType::Fire`: armor protects like Blunt, never cripples; autofire + 3-round-burst helpers; noise formula per Hausregeln — **found a wiki typo: the AK-at-200m example says 38, the formula gives 37**
- `check_ranged_attack` (WA + scope), `weapon_damage` (melee adds DAM)

## M6 — Character creation (#9)
- Validations: 60 attribute points (2–9, INT/REF ≥ 5, no 10), skill caps (one 8/one 7/two 6, 1:2 tradeable — wiki example is a test), budget (INT+REF+40+age points; disadvantages grant CP), starting money incl. Reich doubling
- **Lifepath (Q29)**: data-driven d10 tables with goto-chaining; `data/lifepath_classic.toml` is a **best-effort transcription** (core book is a text-less scan — please review against p.35ff), `lifepath_desaster.toml` starts as your editable copy. CLI: `cargo run -- chargen [--classic|--desaster] [name] [role] [age]`
- **Trait catalog (Q30)**: all wiki Vor-/Nachteile in `data/advantages.toml` — GUESS comments mark my modifier interpretations, ENGINE-TODO marks rules needing future engine hooks (half-Prellschaden, RUN factor, Pech, Bluter)
- `generate_nsc()`: rules-valid random attributes + rolled lifepath; skills/gear left to the GM

**Review focus** (everything else is rules-as-decided): `data/lifepath_classic.toml`, the GUESS lines in `data/advantages.toml`, Sling/Molotov stats.

47 new tests — 109 total, all passing; fmt clean; clippy only the 2 deferred constructor warnings.

Closes #15, closes #21, closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)